### PR TITLE
RFC: Remove ASCII requirement on strings when possible

### DIFF
--- a/src/geom/point.jl
+++ b/src/geom/point.jl
@@ -83,7 +83,7 @@ function render(geom::PointGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
         stroke_colors =
             Gadfly.pooled_map(RGBA{Float32}, theme.discrete_highlight_color, aes.color)
         classes =
-            Gadfly.pooled_map(ASCIIString,
+            Gadfly.pooled_map(AbstractString,
                 c -> svg_color_class_from_label(escape_id(aes.color_label([c])[1])),
                 aes.color)
 


### PR DESCRIPTION
As shown in #786, using `ASCIIString` might be too restrictive.  While the current change will allow the specific test case in #786 to run, we might want to consider replacing all the `ASCIIString`'s with `AbstractString`'s.  Can anyone think of a reason why that might not be a good idea?
