### PR TITLE
Fixes #842 + adds alpha for color aesthetic

### DIFF
--- a/src/scale.jl
+++ b/src/scale.jl
@@ -242,6 +242,10 @@ function apply_scale(scale::ContinuousScale,
                 end
             end
 
+            if T <: Measure
+                T = Measure
+            end
+
             ds = Gadfly.hasna(vals) ? DataArray(T, length(vals)) : Array(T, length(vals))
             apply_scale_typed!(ds, vals, scale)
 

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -979,7 +979,7 @@ function minvalmaxval{T}(minval::T, maxval::T, val, s, ds)
         maxval = val
     end
 
-    if s != nothing
+    if s != nothing && !(typeof(s) <: Measure)
         minval = min(minval, val - s)::T
         maxval = max(maxval, val + s)::T
     end

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -62,6 +62,9 @@ function default_middle_color(fill_color::TransparentColor)
         fill_color.alpha)
 end
 
+function default_alpha_color(fill_color::Colorant)
+    return fill_color
+end
  
 get_stroke_vector(::@compat(Void)) = []
 get_stroke_vector(vec::AbstractVector) = vec
@@ -180,6 +183,8 @@ end
 
     # Width of the middle line in a boxplot.
     middle_width,          Measure,         0.6mm
+
+    alpha_color,            Function,       default_alpha_color
 
     # Horizontal position of the title of color key guides. One of :left,
     # :right, :center.


### PR DESCRIPTION
This PR enables the `size` aesthetic for `Geom.point` (fixes #842), and also enables alpha transparency when using `Geom.point` with the `color` aesthetic. Note that the size aesthetic needs to be of type `Measure`. Example:

``` julia
using RDatasets, DataFrames
msleep = dataset("ggplot2", "msleep")
D = msleep[:,[:Vore,:BrainWt,:BodyWt,:SleepTotal]]
complete_cases!(D)
D[:Sleep] = [ sqrt(x/pi)*mm for x in D[:SleepTotal]  ]

theme(alpha) = Theme(alpha_color=c ->  Colors.RGBA{Float32}(c.r, c.g, c.b, alpha)) 

p = plot(D, x=:BodyWt, y=:BrainWt, size=:Sleep, Geom.point,
    color=:Vore, theme(0.65),
    Scale.x_log10, Scale.y_log10,
    Guide.title("Sleep times of Mammals")
)
```

![issue842](https://cloud.githubusercontent.com/assets/18226881/18326515/77694cdc-7589-11e6-894b-8c3f91fff67f.png)
