### PR TITLE
Juno fixes

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -1134,13 +1134,13 @@ import Juno: Juno, @render, media, Media, Hiccup
 media(Plot, Media.Plot)
 
 @render Juno.PlotPane p::Plot begin
-  x, y = Juno.plotsize()
-  set_default_plot_size(x*Gadfly.px, y*Gadfly.px)
-  HTML(stringmime("text/html", p))
+    x, y = Juno.plotsize()
+    set_default_plot_size(x*Gadfly.px, y*Gadfly.px)
+    HTML(stringmime("text/html", p))
 end
 
 @render Juno.Editor p::Gadfly.Plot begin
-  Juno.icon("graph")
+    Juno.icon("graph")
 end
 
 include("coord.jl")

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -38,6 +38,8 @@ function __init__()
             warn("Error loading Gadfly theme $theme (set by GADFLY_THEME env variable)")
             show(err)
         end
+    else
+        push_theme(Juno.isactive() ? :dark : :default)
     end
 end
 
@@ -1134,8 +1136,7 @@ media(Plot, Media.Plot)
 @render Juno.PlotPane p::Plot begin
   x, y = Juno.plotsize()
   set_default_plot_size(x*Gadfly.px, y*Gadfly.px)
-  Hiccup.div(Dict(:style=>"background: white"),
-                  HTML(stringmime("text/html", p)))
+  HTML(stringmime("text/html", p))
 end
 
 @render Juno.Editor p::Gadfly.Plot begin


### PR DESCRIPTION
I've altered the default theme setting to work to be in line with what PlotlyJS.jl does. We check if we're booted inside Juno and set the theme accordingly there.

I also removed the white background from the Gadfly render output, which is no longer necessary.