### PR TITLE
Hide API pages in the sidebar

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,7 @@ load_dir(x) = map(file -> joinpath("lib", x, file), readdir(joinpath(Base.source
 makedocs(
     modules = [Gadfly],
     clean = false,
-    format = Documenter.Formats.HTML,
+    format = :html,
     sitename = "Gadfly.jl",
     pages = Any[
         "Home" => "index.md",
@@ -15,19 +15,14 @@ makedocs(
             "Stacks & Layers" => "man/layers.md",
             "Backends" => "man/backends.md",
             "Themes" => "man/themes.md",
-            "Geometries" => "man/geometries.md",
-            "Guides" => "man/guides.md",
-            "Statistics" => "man/stats.md",
-            "Coords" => "man/coords.md",
-            "Scales" => "man/scales.md"
         ],
         "Library" => Any[
             "Rendering Pipeline" => "lib/dev_pipeline.md",
-            "geoms" => load_dir("geoms"),
-            "guides" => load_dir("guides"),
-            "stats" => load_dir("stats"),
-            "coords" => load_dir("coords"),
-            "scales" => load_dir("scales")
+            hide("Geometries" => "lib/geometries.md", load_dir("geoms")),
+            hide("Guides" => "lib/guides.md", load_dir("guides")),
+            hide("Statistics" => "lib/stats.md", load_dir("stats")),
+            hide("Coords" => "lib/coords.md", load_dir("coords")),
+            hide("Scales" => "lib/scales.md", load_dir("scales")),
         ]
     ]
 )

--- a/docs/src/lib/coords.md
+++ b/docs/src/lib/coords.md
@@ -9,6 +9,6 @@ Coordinate systems are mappings between a coordinate space and the 2D rendered o
 ## Available Coordinates
 
 ```@contents
-Pages = map(file -> joinpath("..", "lib", "coords", file), readdir(joinpath("..", "lib", "coords")))
+Pages = map(file -> joinpath("coords", file), readdir("coords"))
 Depth = 1
 ```

--- a/docs/src/lib/geometries.md
+++ b/docs/src/lib/geometries.md
@@ -13,6 +13,6 @@ with those same two aesthetics.
 ## Available Geometries
 
 ```@contents
-Pages = map(file -> joinpath("..", "lib", "geoms", file), readdir(joinpath("..", "lib", "geoms")))
+Pages = map(file -> joinpath("geoms", file), readdir("geoms"))
 Depth = 1
 ```

--- a/docs/src/lib/guides.md
+++ b/docs/src/lib/guides.md
@@ -13,6 +13,6 @@ while guides have some special layout considerations.
 ## Available Guides
 
 ```@contents
-Pages = map(file -> joinpath("..", "lib", "guides", file), readdir(joinpath("..", "lib", "guides")))
+Pages = map(file -> joinpath("guides", file), readdir("guides"))
 Depth = 1
 ```

--- a/docs/src/lib/scales.md
+++ b/docs/src/lib/scales.md
@@ -14,6 +14,6 @@ identified.
 ## Available Scales
 
 ```@contents
-Pages = map(file -> joinpath("..", "lib", "scales", file), readdir(joinpath("..", "lib", "scales")))
+Pages = map(file -> joinpath("scales", file), readdir("scales"))
 Depth = 1
 ```

--- a/docs/src/lib/stats.md
+++ b/docs/src/lib/stats.md
@@ -13,6 +13,6 @@ hinge, and upper and lower fence aesthetics.
 ## Available Statistics
 
 ```@contents
-Pages = map(file -> joinpath("..", "lib", "stats", file), readdir(joinpath("..", "lib", "stats")))
+Pages = map(file -> joinpath("stats", file), readdir("stats"))
 Depth = 1
 ```


### PR DESCRIPTION
Use the new `hide` feature of Documenter to hide a bunch of pages in the sidebar. Also, move the index pages to the Library section since they feel more like an API reference rather than a manual page.

Demo: http://mortenpi.eu/Gadfly.jl/docs-hidden-pages/

If you'd like to keep the Geometries etc. pages under Manual, I'd be happy to make the change, just this way felt better to me.

**Important:** Documenter `v0.6.0` has to be published on METADATA (JuliaLang/METADATA.jl#6776) before this can be merged.