### PR TITLE
add methods to display h/v stacks

### DIFF
--- a/docs/src/man/layers.md
+++ b/docs/src/man/layers.md
@@ -57,8 +57,8 @@ plot details than is available with [Geom.subplot_grid](@ref).
 ```julia
 p1 = plot(x=[1,2,3], y=[4,5,6])
 p2 = plot(x=[1,2,3], y=[6,7,8])
-draw(PDF("p1and2.pdf", 6inch, 6inch), vstack(p1,p2))
+vstack(p1,p2)
 p3 = plot(x=[5,7,8], y=[8,9,10])
 p4 = plot(x=[5,7,8], y=[10,11,12])
-draw(PDF("p1to4.pdf", 6inch, 9inch), vstack(hstack(p1,p2),hstack(p3,p4)))
+vstack(hstack(p1,p2),hstack(p3,p4))
 ```

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -1036,7 +1036,7 @@ Render `p` to a multimedia display, typically an internet browser.
 This function is handy when rendering by `plot` has been suppressed
 with either trailing semi-colon or by calling it within a function.
 """
-function display(p::Plot)
+function display(p::Union{Plot,Compose.Context})
     displays = Base.Multimedia.displays
     for i = length(displays):-1:1
         m = default_mime()
@@ -1066,7 +1066,7 @@ end
 
 # Fallback display method. When there isn't a better option, we write to a
 # temporary file and try to open it.
-function display(d::REPLDisplay, ::MIME"image/png", p::Plot)
+function display(d::REPLDisplay, ::MIME"image/png", p::Union{Plot,Compose.Context})
     filename = string(tempname(), ".png")
     output = open(filename, "w")
     draw(PNG(output, Compose.default_graphic_width,
@@ -1075,7 +1075,7 @@ function display(d::REPLDisplay, ::MIME"image/png", p::Plot)
     open_file(filename)
 end
 
-function display(d::REPLDisplay, ::MIME"image/svg+xml", p::Plot)
+function display(d::REPLDisplay, ::MIME"image/svg+xml", p::Union{Plot,Compose.Context})
     filename = string(tempname(), ".svg")
     output = open(filename, "w")
     draw(SVG(output, Compose.default_graphic_width,
@@ -1084,7 +1084,7 @@ function display(d::REPLDisplay, ::MIME"image/svg+xml", p::Plot)
     open_file(filename)
 end
 
-function display(d::REPLDisplay, ::MIME"text/html", p::Plot)
+function display(d::REPLDisplay, ::MIME"text/html", p::Union{Plot,Compose.Context})
     filename = string(tempname(), ".html")
     output = open(filename, "w")
 
@@ -1117,7 +1117,7 @@ function display(d::REPLDisplay, ::MIME"text/html", p::Plot)
     open_file(filename)
 end
 
-function display(d::REPLDisplay, ::MIME"application/postscript", p::Plot)
+function display(d::REPLDisplay, ::MIME"application/postscript", p::Union{Plot,Compose.Context})
     filename = string(tempname(), ".ps")
     output = open(filename, "w")
     draw(PS(output, Compose.default_graphic_width,
@@ -1126,7 +1126,7 @@ function display(d::REPLDisplay, ::MIME"application/postscript", p::Plot)
     open_file(filename)
 end
 
-function display(d::REPLDisplay, ::MIME"application/pdf", p::Plot)
+function display(d::REPLDisplay, ::MIME"application/pdf", p::Union{Plot,Compose.Context})
     filename = string(tempname(), ".pdf")
     output = open(filename, "w")
     draw(PDF(output, Compose.default_graphic_width,


### PR DESCRIPTION
i'm not super familiar with the Gadfly codebase, or even intended API, but i find displaying plots in the browser super useful.  this PR adds the ability to display stacks as well.