### PR TITLE
title(), gridstack()

### DIFF
--- a/docs/src/man/layers.md
+++ b/docs/src/man/layers.md
@@ -52,7 +52,8 @@ plt=plot(layer(x=rand(10), y=rand(10), Geom.point),
 
 Plots can also be stacked horizontally with `hstack` or vertically with `vstack`.
 This allows more customization in regards to tick marks, axis labeling, and other
-plot details than is available with [Geom.subplot_grid](@ref).
+plot details than is available with [Geom.subplot_grid](@ref).  Use `title` to add
+a descriptive string at the top.
 
 ```julia
 p1 = plot(x=[1,2,3], y=[4,5,6])
@@ -61,4 +62,5 @@ vstack(p1,p2)
 p3 = plot(x=[5,7,8], y=[8,9,10])
 p4 = plot(x=[5,7,8], y=[10,11,12])
 vstack(hstack(p1,p2),hstack(p3,p4))
+title("My great data", hstack(p3,p4))
 ```

--- a/docs/src/man/layers.md
+++ b/docs/src/man/layers.md
@@ -2,10 +2,10 @@
 Author = "Daniel C. Jones"
 ```
 
-# Stacks and Layers
+# Layers and Stacks
 
-**Gadfly** also supports more advanced plot composition techniques like stacking
-and layering.
+**Gadfly** also supports more advanced plot composition techniques like layering
+and stacking.
 
 ## Layers
 
@@ -50,7 +50,8 @@ plt=plot(layer(x=rand(10), y=rand(10), Geom.point),
 
 ## Stacks
 
-Plots can also be stacked horizontally with `hstack` or vertically with `vstack`.
+Plots can also be stacked horizontally with `hstack` or vertically with `vstack`,
+and arranged into a rectangular array with `gridstack`.
 This allows more customization in regards to tick marks, axis labeling, and other
 plot details than is available with [Geom.subplot_grid](@ref).  Use `title` to add
 a descriptive string at the top.
@@ -59,8 +60,13 @@ a descriptive string at the top.
 p1 = plot(x=[1,2,3], y=[4,5,6])
 p2 = plot(x=[1,2,3], y=[6,7,8])
 vstack(p1,p2)
+
 p3 = plot(x=[5,7,8], y=[8,9,10])
 p4 = plot(x=[5,7,8], y=[10,11,12])
+
+# these two are equivalent
 vstack(hstack(p1,p2),hstack(p3,p4))
+gridstack([p1 p2; p3 p4])
+
 title("My great data", hstack(p3,p4))
 ```

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -24,7 +24,7 @@ export Plot, Layer, Theme, Col, Scale, Coord, Geom, Guide, Stat, render, plot,
 
 
 # Re-export some essentials from Compose
-export SVGJS, SVG, PGF, PNG, PS, PDF, draw, inch, mm, cm, px, pt, color, @colorant_str, vstack, hstack
+export SVGJS, SVG, PGF, PNG, PS, PDF, draw, inch, mm, cm, px, pt, color, @colorant_str, vstack, hstack, title
 
 
 function __init__()
@@ -934,6 +934,22 @@ function draw(backend::Compose.Backend, p::Plot)
     draw(backend, render(p))
 end
 
+"""
+    title(ctx::Context, str::String, props::Property...) -> Context
+
+Add a title string to a group of plots, typically created with `vstack`, `hstack`, or `gridstack`.
+
+# Examples
+
+```
+p1 = plot(x=[1,2], y=[3,4], Geom.line);
+p2 = plot(x=[1,2], y=[4,3], Geom.line);
+title(hstack(p1,p2), "my latest data", Compose.fontsize(18pt), fill(colorant"red"))
+```
+"""
+title(ctx::Context, str::String, props::Compose.Property...) = vstack(
+    compose(context(0, 0, 1, 0.1), text(0.5, 1.0, str, hcenter, vbottom), props...),
+    compose(context(0, 0, 1, 0.9), ctx))
 
 # Convenience stacking functions
 """

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -24,7 +24,7 @@ export Plot, Layer, Theme, Col, Scale, Coord, Geom, Guide, Stat, render, plot,
 
 
 # Re-export some essentials from Compose
-export SVGJS, SVG, PGF, PNG, PS, PDF, draw, inch, mm, cm, px, pt, color, @colorant_str, vstack, hstack, title
+export SVGJS, SVG, PGF, PNG, PS, PDF, draw, inch, mm, cm, px, pt, color, @colorant_str, vstack, hstack, title, gridstack
 
 
 function __init__()
@@ -980,6 +980,11 @@ hstack(ps::Vector{Plot}) = hstack(Context[render(p) for p in ps]...)
 hstack(p::Plot, c::Context) = hstack(render(p), c)
 hstack(c::Context, p::Plot) = hstack(c, render(p))
 
+"""
+    gridstack(ps::Matrix{Plot}) -> Context
+
+Arrange plots into a rectangular array.
+"""
 gridstack(ps::Matrix{Plot}) = gridstack(map(render, ps))
 
 # show functions for all supported compose backends.

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 RDatasets
 Cairo
+Compose

--- a/test/gridstack.jl
+++ b/test/gridstack.jl
@@ -1,0 +1,7 @@
+using Gadfly
+
+p1 = plot(x=[1,2,3], y=[4,5,6])
+p2 = plot(x=[1,2,3], y=[6,7,8])
+p3 = plot(x=[5,7,8], y=[8,9,10])
+p4 = plot(x=[5,7,8], y=[10,11,12])
+gridstack([p1 p2; p3 p4])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ tests = [
     ("multicolumn_colorkey",                  6inch, 2inch),
     ("vstack",                                6inch, 6inch),
     ("hstack",                                6inch, 3inch),
+    ("title",                                 6inch, 3inch),
     ("colorful_hist",                         6inch, 3inch),
     ("discrete_histogram",                    6inch, 3inch),
     ("discrete_bar",                          6inch, 3inch),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ tests = [
     ("vstack",                                6inch, 6inch),
     ("hstack",                                6inch, 3inch),
     ("title",                                 6inch, 3inch),
+    ("gridstack",                             6inch, 3inch),
     ("colorful_hist",                         6inch, 3inch),
     ("discrete_histogram",                    6inch, 3inch),
     ("discrete_bar",                          6inch, 3inch),

--- a/test/title.jl
+++ b/test/title.jl
@@ -1,0 +1,5 @@
+using Gadfly, Compose
+
+p1 = plot(x=[1,2,3], y=[4,5,6], Geom.point);
+p2 = plot(x=[1,2,3], y=[4,5,6], Geom.line);
+title(vstack(p1,p2), "foo", font("helvetica"))


### PR DESCRIPTION
closes https://github.com/GiovineItalia/Gadfly.jl/issues/600

specifically, this PR adds `title` which puts a string at the top of a `vstack` or `hstack`, as described in the issue above.

a second commit, which i could put into a separate PR if you like, documents the already existing yet not exported `gridstack`.  i took the liberty of exporting it.

lastly, i changed the "Stacks and Layers" header to "Layers and Stacks" to match the order of the subsequent subsections.