### PR TITLE
fix Theme.line_style

### DIFF
--- a/docs/src/lib/geoms/geom_abline.md
+++ b/docs/src/lib/geoms/geom_abline.md
@@ -20,6 +20,7 @@ plot canvas.
 
   * `color`: Color of the lines.
   * `size`: Width of the lines.
+  * `style`: Style of the lines.
 
 ## Examples
 
@@ -30,6 +31,6 @@ Gadfly.set_default_plot_size(14cm, 10cm)
 
 ```@example 1
 plot(dataset("ggplot2", "mpg"), x="Cty", y="Hwy", label="Model", Geom.point, Geom.label,
-    yintercept=[0], xslope=[1], Geom.abline(color="red"),
+    yintercept=[0], xslope=[1], Geom.abline(color="red", style=:dash),
     Guide.annotation(compose(context(), text(6,4, "y=x", hleft, vtop), fill(colorant"red"))))
 ```

--- a/docs/src/lib/geoms/geom_hline.md
+++ b/docs/src/lib/geoms/geom_hline.md
@@ -14,6 +14,7 @@ Draw horizontal lines across the plot canvas.
 
   * `color`: Color of the lines.
   * `size`: Width of the lines.
+  * `style`: Style of the lines.
 
 ## Examples
 
@@ -25,7 +26,7 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 
 ```@example 1
 plot(dataset("datasets", "iris"), x="SepalLength", y="SepalWidth",
-   yintercept=[2.5, 4.0], Geom.point, Geom.hline)
+   yintercept=[2.5, 4.0], Geom.point, Geom.hline(style=:dot))
 ```
 
 ```@example 1

--- a/docs/src/lib/geoms/geom_vline.md
+++ b/docs/src/lib/geoms/geom_vline.md
@@ -14,6 +14,7 @@ Draw vertical lines across the plot canvas.
 
   * `color`: Color of the lines.
   * `size`: Width of the lines.
+  * `style`: Style of the lines.
 
 ## Examples
 
@@ -25,7 +26,7 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 
 ```@example 1
 plot(dataset("datasets", "iris"), x="SepalLength", y="SepalWidth",
-   xintercept=[5.0, 7.0], Geom.point, Geom.vline)
+   xintercept=[5.0, 7.0], Geom.point, Geom.vline(style=[:solid,[1mm,1mm]]))
 ```
 
 ```@example 1

--- a/docs/src/man/themes.md
+++ b/docs/src/man/themes.md
@@ -29,6 +29,7 @@ These parameters can either be used with `Theme` or `style`
   * `default_point_size`: Size of points in the point and boxplot geometry.
      (Measure)
   * `line_width`: Width of lines in the line geometry. (Measure)
+  * `line_style`: Style of lines in the line geometry. (Symbol in :solid, :dash, :dot, :dashdot, :dashdotdot, or Vector of Measures)
   * `panel_fill`: Background color used in the main plot panel. (
     Color or Nothing)
   * `panel_opacity`: Opacity of the plot background panel. (Float in [0.0, 1.0])

--- a/src/geom/segment.jl
+++ b/src/geom/segment.jl
@@ -61,31 +61,26 @@ function render(geom::SegmentGeom, theme::Gadfly.Theme, aes::Gadfly.Aesthetics,
 
     aes = inherit(aes, default_aes) 
 
-#    line_style = Gadfly.get_stroke_vector(theme.line_style)
-    line_style = theme.line_style 
-    if is(line_style, nothing)
-        line_style = [] 
+    line_style = Gadfly.get_stroke_vector(theme.line_style)
+
+    # Geom.vector requires information about scales
+
+    if geom.arrow
+        xscale = scales[:x]
+        yscale = scales[:y]
+        check = [xscale.minvalue, xscale.maxvalue, yscale.minvalue, yscale.maxvalue]
+        if any( map(x -> is(x,nothing), check) )
+            error("For Geom.vector, Scale minvalue and maxvalue must be manually provided for both axes")
+        end
+        fx = xscale.trans.f
+        fy = yscale.trans.f
+        xyrange = [fx(xscale.maxvalue)-fx(xscale.minvalue),
+            fy(yscale.maxvalue)-fy(yscale.minvalue)]
+
+         arrows = [ arrow(x, y, xend, yend, xyrange)
+                for (x, y, xend, yend) in zip(aes.x, aes.y, aes.xend, aes.yend) ]
+
     end
-
-
-# Geom.vector requires information about scales
-
-if geom.arrow
-    xscale = scales[:x]
-    yscale = scales[:y]
-    check = [xscale.minvalue, xscale.maxvalue, yscale.minvalue, yscale.maxvalue]
-    if any( map(x -> is(x,nothing), check) )
-        error("For Geom.vector, Scale minvalue and maxvalue must be manually provided for both axes")
-    end
-    fx = xscale.trans.f
-    fy = yscale.trans.f
-    xyrange = [fx(xscale.maxvalue)-fx(xscale.minvalue),
-        fy(yscale.maxvalue)-fy(yscale.minvalue)]
-
-     arrows = [ arrow(x, y, xend, yend, xyrange)
-            for (x, y, xend, yend) in zip(aes.x, aes.y, aes.xend, aes.yend) ]
-
-end
 
     
     segments = [ [(x,y), (xend,yend)]

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -66,9 +66,9 @@ end
 get_stroke_vector(::@compat(Void)) = []
 get_stroke_vector(vec::AbstractVector) = vec
 function get_stroke_vector(linestyle::Symbol)
-  dash = 12 * Compose.mm
-  dot = 3 * Compose.mm
-  gap = 2 * Compose.mm
+  dash = 4 * Compose.mm
+  dot = 2 * Compose.mm
+  gap = 1 * Compose.mm
   linestyle == :solid && return []
   linestyle == :dash && return [dash, gap]
   linestyle == :dot && return [dot, gap]
@@ -91,7 +91,7 @@ end
 
     # type of dash style (a Compose.StrokeDash object which takes a vector of sold/missing/solid/missing/... 
     # lengths which are applied cyclically)
-    line_style,            Maybe(Vector),   nothing
+    line_style,            Union{Symbol,Vector},   :solid
 
     # Background color of the plot.
     panel_fill,            ColorOrNothing,  nothing

--- a/test/hvabline.jl
+++ b/test/hvabline.jl
@@ -4,14 +4,14 @@ using Gadfly, RDatasets, Compose
 plot(sin, 0, 25,
      xintercept=[0, pi, 2pi, 3pi],
      yintercept=[0, -1, 1],
-     Geom.hline, Geom.vline)
+     Geom.hline(style=[:dot,[1mm,1mm],:solid]), Geom.vline(style=:dashdot))
 
 plot(dataset("datasets", "iris"), x="SepalLength", y="SepalWidth",
    yintercept=[2.5, 4.0], Geom.point,
    Geom.hline(color=["orange","red"], size=[2mm,3mm]))
 
 plot(dataset("ggplot2", "mpg"), x="Cty", y="Hwy", label="Model", Geom.point, Geom.label,
-    yintercept=[0], xslope=[1], Geom.abline(color="red"),
+    yintercept=[0], xslope=[1], Geom.abline(color="red", style=:dash),
     Guide.annotation(compose(context(), text(6,4, "y=x", hleft, vtop), fill(colorant"red"))))
 
 # issue 961


### PR DESCRIPTION
closes https://github.com/GiovineItalia/Gadfly.jl/issues/392
fixes https://github.com/GiovineItalia/Gadfly.jl/pull/706

permit user to specify dashed, dotted, or a custom pattern for `Geom.{line,hline,vline,abline}`.

includes tests and docs