### PR TITLE
Compose.line called with wrong object type in render

### DIFF
--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -159,7 +159,7 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
             sort!(points, by=first)
         end
 
-        ctx = compose!(ctx, Compose.line(points,geom.tag),
+        ctx = compose!(ctx, Compose.line([points],geom.tag),
                        stroke(aes.color[1]),
                        strokedash(line_style),
                        svgclass("geometry"))


### PR DESCRIPTION
In case

elseif length(aes.color) == 1 &&
            !(isa(aes.color, PooledDataArray) && length(levels(aes.color)) > 1)

the Compose.line is called with the wrong type (it expects array of array of tuple; compare else branch).