### PR TITLE
Fix wrong coercion of aes.x values to Float64 in apply_statistics

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1240,7 +1240,7 @@ function apply_statistic(stat::SmoothStatistic,
             end
         end
 
-        aes.x = Array(Float64, length(groups) * num_steps)
+        aes.x = Array(eltype(aes.x), length(groups) * num_steps)
         aes.y = Array(Float64, length(groups) * num_steps)
         colors = Array(RGB{Float32}, length(groups) * num_steps)
 


### PR DESCRIPTION
In case DateTime is used for x values, the aes.x gets the wrong type (compare type of aes.x in aes.color == nothing case).
Keep the element type. Otherwise you get errors like

ERROR: MethodError: no method matching -(::Float64, ::DateTime)
Closest candidates are:
  -(::Float64, !Matched::Float64) at float.jl:242
  -(::Float64) at float.jl:237
  -(!Matched::Base.Dates.CompoundPeriod, ::Base.Dates.TimeType) at dates/periods.jl:367
  ...
 in resolve_position(::Measures.BoundingBox{Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}},Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}}}, ::Compose.UnitBox{DateTime,Float64,Base.Dates.Millisecond,Float64}, ::Compose.IdentityTransform, ::Measures.Length{:cx,Float64}) at /home/tr/.julia/v0.5/Compose/src/measure.jl:387
 in resolve at /home/tr/.julia/v0.5/Compose/src/measure.jl:407 [inlined]
 in #47 at ./<missing>:0 [inlined]
 in next at ./generator.jl:26 [inlined]
 in copy!(::Array{Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}},1}, ::Base.Generator{Array{Tuple{Measures.Measure,Measures.Measure},1},Compose.##47#48{Measures.BoundingBox{Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}},Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}}},Compose.UnitBox{DateTime,Float64,Base.Dates.Millisecond,Float64},Compose.IdentityTransform}}) at ./abstractarray.jl:477
 in resolve(::Measures.BoundingBox{Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}},Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}}}, ::Compose.UnitBox{DateTime,Float64,Base.Dates.Millisecond,Float64}, ::Compose.IdentityTransform, ::Compose.LinePrimitive{Tuple{Measures.Measure,Measures.Measure}}) at /home/tr/.julia/v0.5/Compose/src/form.jl:549