### PR TITLE
New Stat.smooth

### DIFF
--- a/test/issue975.jl
+++ b/test/issue975.jl
@@ -1,0 +1,27 @@
+
+using DataFrames, Gadfly
+
+# Geom.smooth already has tests for these types:
+# Floats: smooth_lm.jl
+# Ints: subplot_layers.jl
+
+# This adds tests for Date and DateTime objects
+
+t1 = Date("2001-01-15"):Dates.Month(1):Date("2016-12-31")
+t2 = DateTime("2001-01-15"):Dates.Month(1):DateTime("2016-12-31")
+t = convert(Vector{Float64}, t1) 
+n = length(t)
+D = DataFrame(t1=t1, t2=t2, cycle = 5*sin(t*2π/365.25)+randn(n), trend = 0.1*[1.0:n;].+2*randn(n))
+Dl = melt(D,[:t1,:t2])
+
+plot(D,
+    x=:t1, y=:trend, Geom.point,
+    Geom.smooth(method=:lm),
+    Theme(default_point_size=1.8pt, key_position=:none)
+    )
+
+plot(Dl,
+    x=:t2, y=:value, color=:variable, Geom.point,
+    Geom.smooth(smoothing=0.05),
+    Theme(default_point_size=1.8pt, key_position=:none)
+    )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,7 +119,8 @@ tests = [
     ("beeswarm",                              6inch, 3inch),
     ("issue871",                              6inch, 3inch),
     ("issue882",                              6inch, 3inch),
-    ("vector",                                3.3inch, 3.3inch)
+    ("vector",                                3.3inch, 3.3inch),
+    ("issue975",                              6inch, 3inch)
 ]
 
 


### PR DESCRIPTION
This PR implements a new version of `Stat.smooth` (which is called by `Geom.smooth`). It
* works when `x` is a `Date` or `DateTime` object (fixes #975)
* enables both smoothing methods i.e. `method=:loess` or `method=:lm`
* works for the examples in #975
* has more compact, readable code!
Wrt the last point, aesthetics without a `color` aesthetic are now treated as a single group. This leads to more compact code, easier to maintain.
