### PR TITLE
simplify Geom.abline to use just intercept and slope; Coord now ignores it

### DIFF
--- a/docs/src/lib/geoms/geom_abline.md
+++ b/docs/src/lib/geoms/geom_abline.md
@@ -4,17 +4,15 @@ Author = "Ben J. Arthur"
 
 # Geom.abline
 
-For each number in `yintercept`, draw the lines `y = xslope * x +
-yintercept` across the plot canvas.  Similarly, for each number in
-`xintercept`, draw the lines `x = yslope * y + xintercept` across the
-plot canvas.
+For each corresponding pair of elements in `intercept` and `slope`, draw the
+lines `y = slope * x + intercept` across the plot canvas.
+
+Currently does not support non-linear `Scale` transformations.
 
 ## Aesthetics
 
-  * `yintercept`: Y-axis intercepts
-  * `xslope`: rise over run, defaults to 0
-  * `xintercept`: X-axis intercepts
-  * `yslope`: run over rise, defaults to 0
+  * `intercept`: Y-axis intercepts, defaults to [0]
+  * `slope`: rise over run, defaults to [1]
 
 ## Arguments
 
@@ -31,6 +29,6 @@ Gadfly.set_default_plot_size(14cm, 10cm)
 
 ```@example 1
 plot(dataset("ggplot2", "mpg"), x="Cty", y="Hwy", label="Model", Geom.point, Geom.label,
-    yintercept=[0], xslope=[1], Geom.abline(color="red", style=:dash),
+    intercept=[0], slope=[1], Geom.abline(color="red", style=:dash),
     Guide.annotation(compose(context(), text(6,4, "y=x", hleft, vtop), fill(colorant"red"))))
 ```

--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -35,8 +35,8 @@ const NumericalAesthetic =
     # fixed lines
     xintercept,   NumericalAesthetic
     yintercept,   NumericalAesthetic
-    xslope,       NumericalAesthetic
-    yslope,       NumericalAesthetic
+    intercept,    NumericalAesthetic
+    slope,        NumericalAesthetic
 
     # boxplots
     middle,       NumericalAesthetic

--- a/src/coord.jl
+++ b/src/coord.jl
@@ -34,8 +34,8 @@ immutable Cartesian <: Gadfly.CoordinateElement
     raster::Bool
 
     function Cartesian(
-            xvars=[:x, :xmin, :xmax, :xintercept, :xslope],
-            yvars=[:y, :ymin, :ymax, :yintercept, :yslope, :middle,
+            xvars=[:x, :xmin, :xmax, :xintercept],
+            yvars=[:y, :ymin, :ymax, :yintercept, :middle,
                    :lower_hinge, :upper_hinge, :lower_fence, :upper_fence, :outliers];
             xflip::Bool=false, yflip::Bool=false,
             xmin=nothing, xmax=nothing, ymin=nothing, ymax=nothing,

--- a/src/data.jl
+++ b/src/data.jl
@@ -14,8 +14,8 @@
     width
     xintercept
     yintercept
-    xslope
-    yslope
+    intercept
+    slope
     middle
     lower_hinge
     upper_hinge

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -162,8 +162,8 @@ function make_labeler(scale::ContinuousScale)
 end
 
 
-const x_vars = [:x, :xmin, :xmax, :xintercept, :xslope, :xviewmin, :xviewmax, :xend]
-const y_vars = [:y, :ymin, :ymax, :yintercept, :yslope, :middle,
+const x_vars = [:x, :xmin, :xmax, :xintercept, :intercept, :xviewmin, :xviewmax, :xend]
+const y_vars = [:y, :ymin, :ymax, :yintercept, :slope, :middle,
                 :upper_fence, :lower_fence, :upper_hinge, :lower_hinge,
     :yviewmin, :yviewmax, :yend]
 

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -769,7 +769,7 @@ function xticks(; ticks::@compat(Union{Symbol, AbstractArray})=:auto,
                   simplicity_weight::Float64=1/6,
                   coverage_weight::Float64=1/3,
                   niceness_weight::Float64=1/4)
-    TickStatistic([:x, :xmin, :xmax, :xintercept, :xslope], "x",
+    TickStatistic([:x, :xmin, :xmax, :xintercept], "x",
                   granularity_weight, simplicity_weight,
                   coverage_weight, niceness_weight, ticks)
 end
@@ -783,7 +783,7 @@ function yticks(; ticks::@compat(Union{Symbol, AbstractArray})=:auto,
                   coverage_weight::Float64=1/3,
                   niceness_weight::Float64=1/4)
     TickStatistic(
-        [:y, :ymin, :ymax, :yintercept, :yslope, :middle, :lower_hinge, :upper_hinge,
+        [:y, :ymin, :ymax, :yintercept, :middle, :lower_hinge, :upper_hinge,
          :lower_fence, :upper_fence], "y",
         granularity_weight, simplicity_weight,
         coverage_weight, niceness_weight, ticks)

--- a/test/hvabline.jl
+++ b/test/hvabline.jl
@@ -11,8 +11,15 @@ plot(dataset("datasets", "iris"), x="SepalLength", y="SepalWidth",
    Geom.hline(color=["orange","red"], size=[2mm,3mm]))
 
 plot(dataset("ggplot2", "mpg"), x="Cty", y="Hwy", label="Model", Geom.point, Geom.label,
-    yintercept=[0], xslope=[1], Geom.abline(color="red", style=:dash),
+    intercept=[0], slope=[1], Geom.abline(color="red", style=:dash),
     Guide.annotation(compose(context(), text(6,4, "y=x", hleft, vtop), fill(colorant"red"))))
+
+plot(x=[2,3,4],y=[2,3,4],Geom.point,intercept=[0],slope=[1],Geom.abline)
+plot(x=[2,3,4],y=[2,3,4],Geom.point,intercept=[0],Geom.abline)
+plot(x=[2,3,4],y=[2,3,4],Geom.point,slope=[1],Geom.abline)
+plot(x=[2,3,4],y=[2,3,4],Geom.point,intercept=[0.1],Geom.abline)
+plot(x=[2,3,4],y=[2,3,4],Geom.point,slope=[1.1],Geom.abline)
+
 
 # issue 961
 day = collect(Date("1960-01-01"):Dates.Day(1):Date("1999-12-31"))


### PR DESCRIPTION
previously the interface supported `y=mx+b` and `x=my+b`.  not only complicated, but deviated from ggplot.  moreover, `Coord` took into account the intercepts when adjusting the axes limits.

this PR simplifies the interface by dropping the `xintercept` and `yslope` arguments and renaming `yintercept` to `intercept` and `xslope` to `slope`.  i also made it such that `Coord` will not zoom out to include the intercept.  lastly, i added defaults such that the `y=x` line will be plotted if no args are specified.

non-linear scale transforms like `Scale.y_log` are still not supported.  really not sure how to re-work the code to handle this.