### PR TITLE
Fixes #774

### DIFF
--- a/src/geom/ribbon.jl
+++ b/src/geom/ribbon.jl
@@ -43,7 +43,7 @@ function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
 
         ctx = compose!(
             context(),
-            Compose.polygon(collect(chain(min_points, max_points))),
+            Compose.polygon([collect(chain(min_points, max_points))]),
             fill(theme.lowlight_color(aes.color[1])))
     else
         XT, YT = eltype(aes_x), promote_type(eltype(aes_ymin), eltype(aes_ymax))


### PR DESCRIPTION
This is a quick fix for #774. It works for `Date` or `DateTime` objects:
```Julia
t1 = Date("2001-01-15"):Dates.Month(1):Date("2008-12-31")
t2 = DateTime("2001-01-15"):Dates.Month(1):DateTime("2008-12-31")
t = convert(Vector{Float64}, t1) 
y= 2*sin(t*2π/365.25)
D = DataFrame(t1=t1, t2=t2, cycle=y, ymin=y-0.5, ymax=y+0.5) 
# can use x=:t1 or x=:t2 in the next line:
p = plot(D, x=:t1, y=:cycle, ymin=:ymin, ymax=:ymax, Geom.line, Geom.ribbon)
```
![issue774a](https://cloud.githubusercontent.com/assets/18226881/25153968/ecfab01a-24d1-11e7-819a-a3b618df7511.png)
