### PR TITLE
fix jitter for categorical data

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -921,14 +921,7 @@ function apply_statistic(stat::TickStatistic,
         tickvisible = fill(true, length(ticks))
         tickscale = fill(1.0, length(ticks))
     elseif categorical
-        ticks = Set{Int}()
-        for val in in_values
-            if isinteger(val) && val > 0
-                push!(ticks, round(Int, val))
-            end
-        end
-        ticks = Int[t for t in ticks]
-        sort!(ticks)
+        ticks = collect( colon(map(x->round(Int, x), extrema(in_values))...) )
         grids = (ticks .- 0.5)[2:end]
         viewmin = minimum(ticks)
         viewmax = maximum(ticks)

--- a/test/issue986.jl
+++ b/test/issue986.jl
@@ -1,0 +1,6 @@
+using Gadfly
+
+# jitter used to not work for categorical data
+
+plot(x=rand(['a','b','c','d'],100), y=rand(100),
+      Geom.point, Scale.x_discrete, Stat.x_jitter(range=0.2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -120,7 +120,8 @@ tests = [
     ("issue871",                              6inch, 3inch),
     ("issue882",                              6inch, 3inch),
     ("vector",                                3.3inch, 3.3inch),
-    ("issue975",                              6inch, 3inch)
+    ("issue975",                              6inch, 3inch),
+    ("issue986",                              6inch, 3inch)
 ]
 
 


### PR DESCRIPTION
`Stat.jitter` used to only work for continuous, not discrete, data.  this PR fixes that.