### PR TITLE
Geom.vectorfield

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,6 +3,7 @@ Colors 0.3.4
 Compat 0.18.0
 Compose 0.5
 Contour 0.1.1
+CoupledFields
 DataFrames 0.4.2
 DataStructures
 Distributions

--- a/docs/src/lib/geoms/geom_vectorfield.md
+++ b/docs/src/lib/geoms/geom_vectorfield.md
@@ -1,0 +1,58 @@
+```@meta
+Author = "Mattriks"
+```
+
+# Geom.vectorfield
+
+Draw a vectorfield of a 2D function or a matrix. A vectorfield consists of gradient vectors calculated for particular points in a space.
+
+## Aesthetics
+
+  * `z`: 2D function or a matrix that represent "heights" relative to
+    to the x-y plane.
+  * `x` (optional): Vector of X-coordinates.  If `z` is a matrix, then
+    the length of `x` must be equal to the number of *rows* in `z`.
+  * `y` (optional): Vector of Y-coordinates.  If `z` is a matrix, then
+    the length of `y` must be equal to the number of *columns* in `z`.
+
+## Arguments
+  * `smoothness` (optional): Sets the smoothness of the vectorfield,
+    defaults to 1.0. Smaller values (→0) result in more local smoothing.
+    Larger values (→∞) will approach a plane of best fit.
+  * `scale` (optional): Sets the size of vectors, defaults to 1.0. 
+  * `samples` (optional): Sets the size of the grid at which to estimate vectors,
+    defaults to 20 (i.e. grid is 20 x 20). See the first example below.
+
+## Examples
+
+```@setup 1
+using RDatasets
+using Gadfly
+Gadfly.set_default_plot_size(14cm, 8cm)
+```
+
+```@example 1
+coord = Coord.cartesian(xmin=-2, xmax=2, ymin=-2, ymax=2)
+plot(coord, z=(x,y)->x*exp(-(x^2+y^2)), 
+        xmin=[-2], xmax=[2], ymin=[-2], ymax=[2], 
+# or:     x=-2:0.25:2.0, y=-2:0.25:2.0,     
+        Geom.vectorfield(scale=0.4, samples=17), Geom.contour(levels=6),
+        Scale.x_continuous(minvalue=-2.0, maxvalue=2.0),
+        Scale.y_continuous(minvalue=-2.0, maxvalue=2.0),
+        Guide.xlabel("x"), Guide.ylabel("y"), Guide.colorkey("z")
+    )
+```
+
+```@example 1
+volcano = Matrix{Float64}(dataset("datasets", "volcano"))
+volc = volcano[1:4:end, 1:4:end] 
+coord = Coord.cartesian(xmin=1, xmax=22, ymin=1, ymax=16)
+plot(coord, z=volc, x=1.0:22, y=1.0:16,
+        Geom.vectorfield(scale=0.05), Geom.contour(levels=7),
+        Scale.x_continuous(minvalue=1.0, maxvalue=22.0),
+        Scale.y_continuous(minvalue=1.0, maxvalue=16.0),
+        Guide.xlabel("x"), Guide.ylabel("y"),
+        Theme(key_position=:none)
+    )
+```
+

--- a/test/vector.jl
+++ b/test/vector.jl
@@ -12,3 +12,26 @@ ysc  = Scale.y_continuous(minvalue=0.0, maxvalue=100)
 plot(D, x=:x1, y=:x2, xend=:x3, yend=:x4, Geom.segment(arrow=true), xsc, ysc)
 plot(D, x=:x1, y=:x2, xend=:x3, yend=:x4, Geom.vector, xsc, ysc)
 
+
+plot(z=(x,y)->x*exp(-(x^2+y^2)), 
+        xmin=[-2], xmax=[2], ymin=[-2], ymax=[2], 
+        Geom.vectorfield(scale=0.4, samples=17),
+        Scale.x_continuous(minvalue=-2.0, maxvalue=2.0),
+        Scale.y_continuous(minvalue=-2.0, maxvalue=2.0),
+        Guide.xlabel("x"), Guide.ylabel("y"), Guide.colorkey("z")
+    )
+
+
+Z = fill(1.0, 5, 5)
+Z[2:4, 2:4] = 2.0
+Z[3,3] = 3.0
+
+plot(z=Z,
+        Geom.vectorfield,
+        Scale.x_continuous(minvalue=1.0, maxvalue=5.0),
+        Scale.y_continuous(minvalue=1.0, maxvalue=5.0),
+        Guide.xlabel("x"), Guide.ylabel("y"), 
+        Theme(key_position=:none)
+    )
+
+


### PR DESCRIPTION
This PR adds `Geom.vectorfield` to Gadfly (requested in #608 and #791). The concepts behind and design of `Geom.vectorfield` are described [here](https://github.com/GiovineItalia/Gadfly.jl/issues/791#issuecomment-292680904). The `z` variable can be a 2D function or a matrix.  Here is another awesome example:

```Julia
coord = Coord.cartesian(xmin=-2, xmax=2, ymin=-2, ymax=2)
p = plot(coord, z=(x,y)->x*exp(-(x^2+y^2)), 
        x=-2:0.25:2.0, y=-2:0.25:2.0,     
        Geom.vectorfield(scale=0.4), Geom.contour(levels=6),
        Scale.x_continuous(minvalue=-2.0, maxvalue=2.0),
        Scale.y_continuous(minvalue=-2.0, maxvalue=2.0),
        Guide.xlabel("x"), Guide.ylabel("y"), Guide.colorkey("z")
    )
```
![issue791b](https://cloud.githubusercontent.com/assets/18226881/25433420/ab283c66-2acb-11e7-81d0-9e40ea8092e3.png)
