### PR TITLE
Geom.rect

### DIFF
--- a/docs/src/lib/geoms/geom_rectbin.md
+++ b/docs/src/lib/geoms/geom_rectbin.md
@@ -1,5 +1,5 @@
 ```@meta
-Author = "Daniel C. Jones"
+Author = "Daniel C. Jones, Mattriks"
 ```
 
 # Geom.rectbin
@@ -9,30 +9,39 @@ Draw colored rectangles.
 ## Aesthetics
   * color
 
-Either
+Either (for `Geom.rect`)
 
   * x_min
   * x_max
   * y_min
   * y_max
 
-Or
+Or (for `Geom.rectbin`)
 
   * x
   * y
 
-In the former case, rectangles defined by `x_min`, `x_max`, `y_min`, `y_max`
-are drawn, in the latter, equal sizes squares are centered at `x` and `y`
+For `Geom.rect`, rectangles defined by `x_min`, `x_max`, `y_min`, `y_max`
+are drawn.  
+For `Geom.rectbin`, equal sizes squares are centered at `x` and `y`
 positions.
 
 ## Examples
 
 ```@setup 1
-using RDatasets
+using DataFrames, RDatasets
 using Gadfly
 Gadfly.set_default_plot_size(14cm, 8cm)
 ```
 
 ```@example 1
 plot(dataset("Zelig", "macro"), x="Year", y="Country", color="GDP", Geom.rectbin)
+```
+
+```@example 1
+theme1 = Theme(default_color=RGBA(0, 0.75, 1.0, 0.5))
+D = DataFrame(x=[0.5,1], y=[0.5,1], x1=[0,0.5], y1=[0,0.5], x2=[1,1.5], y2=[1,1.5])
+pa = plot(D, x=:x, y=:y, Geom.rectbin, theme1)
+pb = plot(D, xmin=:x1, ymin=:y1, xmax=:x2, ymax=:y2, Geom.rect, theme1)
+hstack(pa, pb)
 ```

--- a/src/geom/rectbin.jl
+++ b/src/geom/rectbin.jl
@@ -9,6 +9,8 @@ function RectangularBinGeometry(
     RectangularBinGeometry(default_statistic, tag)
 end
 
+rect() = RectangularBinGeometry(Gadfly.Stat.Identity())
+
 const rectbin = RectangularBinGeometry
 
 function histogram2d(; xbincount=nothing, xminbincount=3, xmaxbincount=150,
@@ -40,7 +42,7 @@ element_aesthetics(::RectangularBinGeometry) =
 function render(geom::RectangularBinGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledDataArray(RGB{Float32}[theme.default_color])
+    default_aes.color = PooledDataArray(RGBA{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
 
     Gadfly.assert_aesthetics_defined("RectangularBinGeometry", aes, :xmin, :xmax, :ymin, :ymax)
@@ -61,7 +63,7 @@ function render(geom::RectangularBinGeometry, theme::Gadfly.Theme, aes::Gadfly.A
     if length(aes.color) == n
         cs = aes.color
     else
-        cs = Array{RGB{Float32}}(n)
+        cs = Array{RGBA{Float32}}(n)
         for i in 1:n
             cs[i] = aes.color[((i - 1) % length(aes.color)) + 1]
         end

--- a/test/rectbin.jl
+++ b/test/rectbin.jl
@@ -1,4 +1,12 @@
 
-using Gadfly, DataArrays, RDatasets
+using DataFrames, Gadfly
 
-plot(dataset("Zelig", "macro"), x="Year", y="Country", color="GDP", Geom.rectbin)
+# using RDatasets
+# plot(dataset("Zelig", "macro"), x="Year", y="Country", color="GDP", Geom.rectbin)
+
+D = DataFrame(x=[0.5,1], y=[0.5,1], x1=[0,0.5], y1=[0,0.5], x2=[1,1.5], y2=[1,1.5])
+pa = plot(D, x=:x, y=:y, Geom.rectbin)
+pb = plot(D, xmin=:x1, ymin=:y1, xmax=:x2, ymax=:y2, Geom.rect)
+hstack(pa,pb)
+
+


### PR DESCRIPTION
Two instances of `RectangularBinGeometry` are necessary:
- `Geom.rectbin` which calls `Stat.rectbin` (takes `x` & `y` aesthetics)
- `Geom.rect` which calls `Stat.Identity` (takes `xmin`, `ymin`, `xmax`, `ymax`)

The former currently exists, this PR adds the latter, and fixes issues #771 & #845.
Note the name `Geom.rect` is used rather than `Geom.rectangle` to avoid conflicts with `Compose.rectangle` (which is widely used without the package specifier in Gadfly code).

Here is an example:
```Julia
theme1 = Theme(default_color=RGBA(0, 0.75, 1.0, 0.5))
D = DataFrame(x=[0.5,1], y=[0.5,1], x1=[0,0.5], y1=[0,0.5], x2=[1,1.5], y2=[1,1.5])
pa = plot(D, x=:x, y=:y, Geom.rectbin, theme1)
pb = plot(D, xmin=:x1, ymin=:y1, xmax=:x2, ymax=:y2, Geom.rect, theme1)
hstack(pa, pb)
```
![issue845a](https://cloud.githubusercontent.com/assets/18226881/25556445/0c00302c-2d40-11e7-9925-722ad31eac6d.png)
