### PR TITLE
fix stat.tick for geom.rectbin

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -755,6 +755,7 @@ function apply_statistic(stat::TickStatistic,
                   (:y in stat.in_vars && Scale.iscategorical(scales, :y))
 
     for var in stat.in_vars
+        categorical && !in(var,[:x,:y]) && continue
         vals = getfield(aes, var)
         if vals != nothing && eltype(vals) != Function
             if minval == nothing
@@ -846,7 +847,12 @@ function apply_statistic(stat::TickStatistic,
         tickvisible = fill(true, length(ticks))
         tickscale = fill(1.0, length(ticks))
     elseif categorical
-        ticks = collect( colon(map(x->round(Int, x), extrema(in_values))...) )
+        ticks = Set{Int}()
+        for val in in_values
+            val>0 && push!(ticks, round(Int, val))
+        end
+        ticks = Int[t for t in ticks]
+        sort!(ticks)
         grids = (ticks .- 0.5)[2:end]
         viewmin = minimum(ticks)
         viewmax = maximum(ticks)

--- a/test/issue996.jl
+++ b/test/issue996.jl
@@ -1,0 +1,7 @@
+using Gadfly
+
+# make sure Stat.ticks work for categorical Geom.rectbin.
+
+J=[-11.0935 -35.9819 12.2814; -9.71891 -31.852 11.2673; -8.51878 -28.1954 10.3279; -7.47033 -24.9582 9.45931; -6.55385 -22.0925 8.65728]
+plotlabels=Any["n","vx","ax"]
+spy(J, Gadfly.Scale.x_discrete(labels = i->plotlabels[i]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,7 +130,8 @@ tests = [
     ("issue882",                              6inch, 3inch),
     ("vector",                                3.3inch, 3.3inch),
     ("issue975",                              6inch, 3inch),
-    ("issue986",                              6inch, 3inch)
+    ("issue986",                              6inch, 3inch),
+    ("issue996",                              6inch, 3inch)
 ]
 
 


### PR DESCRIPTION
closes https://github.com/GiovineItalia/Gadfly.jl/issues/995

@montyvesselinov could you please checkout this PR and make sure it works for Mads.jl?  you'll need to change `Theme(default_point_size...)` to `Theme(point_size...)`.  this change was made recently for brevity.  also, `parse(Colors.Colorant, "red")` can optionally be shortened to `colorant"red"`.