### PR TITLE
fix highlight_color when color aesthetic is specified

### DIFF
--- a/test/issue997.jl
+++ b/test/issue997.jl
@@ -1,0 +1,14 @@
+using Gadfly
+
+# make sure Theme.{discrete,continuous}_highlight_color works for Geom.point.
+
+discrete_with_highlights = plot(x=rand(1:3,100),y=rand(100),color=rand(["a","b"],100),
+            Geom.point, Stat.x_jitter);
+discrete_without_highlights = plot(x=rand(1:3,100),y=rand(100),color=rand(["a","b"],100),
+            Geom.point, Stat.x_jitter, Theme(discrete_highlight_color=x->x));
+continuous_with_highlights = plot(x=rand(1:3,100),y=rand(100),color=rand(1:2,100),
+            Geom.point, Stat.x_jitter);
+continuous_without_highlights = plot(x=rand(1:3,100),y=rand(100),color=rand(1:2,100),
+            Geom.point, Stat.x_jitter, Theme(continuous_highlight_color=x->x));
+gridstack([discrete_with_highlights   discrete_without_highlights
+           continuous_with_highlights continuous_without_highlights])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,7 +131,8 @@ tests = [
     ("vector",                                3.3inch, 3.3inch),
     ("issue975",                              6inch, 3inch),
     ("issue986",                              6inch, 3inch),
-    ("issue996",                              6inch, 3inch)
+    ("issue996",                              6inch, 3inch),
+    ("issue997",                              6inch, 3inch)
 ]
 
 


### PR DESCRIPTION
previously the function specified by `highlight_color` was only called for one of the fill colors.  now it is called individually for each of them.