### PR TITLE
more succinct colors

### DIFF
--- a/docs/src/lib/geoms/geom_abline.md
+++ b/docs/src/lib/geoms/geom_abline.md
@@ -30,5 +30,5 @@ Gadfly.set_default_plot_size(14cm, 10cm)
 ```@example 1
 plot(dataset("ggplot2", "mpg"), x="Cty", y="Hwy", label="Model", Geom.point, Geom.label,
     intercept=[0], slope=[1], Geom.abline(color="red", style=:dash),
-    Guide.annotation(compose(context(), text(6,4, "y=x", hleft, vtop), fill(colorant"red"))))
+    Guide.annotation(compose(context(), text(6,4, "y=x", hleft, vtop), fill("red"))))
 ```

--- a/docs/src/lib/geoms/geom_density.md
+++ b/docs/src/lib/geoms/geom_density.md
@@ -37,8 +37,8 @@ plot(dataset("ggplot2", "diamonds"), x="Price", color="Cut", Geom.density)
 # adjusting bandwidth manually
 dist = MixtureModel(Normal, [(0.5, 0.2), (1, 0.1)])
 xs = rand(dist, 10^5)
-plot(layer(x=xs, Geom.density, Theme(default_color=colorant"orange")), 
-layer(x=xs, Geom.density(bandwidth=0.0003), Theme(default_color=colorant"green")),
-layer(x=xs, Geom.density(bandwidth=0.25), Theme(default_color=colorant"purple")),
+plot(layer(x=xs, Geom.density, Theme(default_color="orange")), 
+layer(x=xs, Geom.density(bandwidth=0.0003), Theme(default_color="green")),
+layer(x=xs, Geom.density(bandwidth=0.25), Theme(default_color="purple")),
 Guide.manual_color_key("bandwidth", ["auto", "bw=0.0003", "bw=0.25"], ["orange", "green", "purple"]))
 ```

--- a/docs/src/lib/guides/guide_annotation.md
+++ b/docs/src/lib/guides/guide_annotation.md
@@ -23,6 +23,5 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 plot(sin, 0, 2pi,
      Guide.annotation(
        compose(context(), circle([pi/2, 3*pi/2], [1.0, -1.0], [2mm]), fill(nothing),
-       stroke(colorant"orange"))))
-
+       stroke("orange"))))
 ```

--- a/docs/src/lib/guides/guide_manual_color_key.md
+++ b/docs/src/lib/guides/guide_manual_color_key.md
@@ -24,7 +24,7 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 ```@example 1
 points = DataFrame(index=rand(0:10,30), val=rand(1:10,30))
 line = DataFrame(val=rand(1:10,11), index = collect(0:10))
-pointLayer = layer(points, x="index", y="val", Geom.point,Theme(default_color=colorant"green"))
+pointLayer = layer(points, x="index", y="val", Geom.point,Theme(default_color="green"))
 lineLayer = layer(line, x="index", y="val", Geom.line)
 plot(pointLayer, lineLayer, Guide.manual_color_key("Legend", ["Points", "Line"], ["green", "deepskyblue"]))
 ```

--- a/docs/src/lib/scales/scale_color_continuous.md
+++ b/docs/src/lib/scales/scale_color_continuous.md
@@ -59,9 +59,7 @@ Or we can use `lab_gradient` to construct a color gradient between 2 or more col
 
 ```@example 1
 plot(x=x, y=y, color=x+y, Geom.rectbin,
-     Scale.color_continuous(colormap=Scale.lab_gradient(colorant"green",
-                                                        colorant"white",
-                                                        colorant"red")))
+     Scale.color_continuous(colormap=Scale.lab_gradient("green", "white", "red")))
 ```
 
 We can also start the color scale somewhere other than the bottom of the data range using `minvalue`:

--- a/docs/src/lib/scales/scale_color_discrete_manual.md
+++ b/docs/src/lib/scales/scale_color_discrete_manual.md
@@ -8,7 +8,7 @@ Create a discrete color scale to be used for the plot.
 
 ## Arguments
 
-  * `colors...`: an iterable collection of things that can be converted to colors with `Colors.color` (such as strings naming colors, although a better choice is to use `colorant"colorname"`)
+  * `colors...`: an iterable collection of things that can be converted to colors with `Colors.color` (e.g. "tomato", RGB(1.0,0.388,0.278), colorant"#FF6347")
   * `levels` (optional): Explicitly set levels used by the scale. Order is
     respected.
   * `order` (optional): A vector of integers giving a permutation of the levels
@@ -27,5 +27,5 @@ srand(1234)
 
 ```@example 1
 plot(x=rand(12), y=rand(12), color=repeat(["a","b","c"], outer=[4]),
-     Scale.color_discrete_manual(colorant"red",colorant"purple",colorant"green"))
+     Scale.color_discrete_manual("red","purple","green"))
 ```

--- a/docs/src/man/themes.md
+++ b/docs/src/man/themes.md
@@ -100,8 +100,8 @@ srand(12345)
 ```@example 1
 
 dark_panel = Theme(
-    panel_fill=colorant"black",
-    default_color=colorant"orange"
+    panel_fill="black",
+    default_color="orange"
 )
 
 plot(x=rand(10), y=rand(10), dark_panel)
@@ -160,7 +160,7 @@ To register a theme by name, you can extend `Gadfly.get_theme(::Val{:theme_name}
 
 ```@example 1
 Gadfly.get_theme(::Val{:orange}) =
-    Theme(default_color=colorant"orange")
+    Theme(default_color="orange")
 
 Gadfly.with_theme(:orange) do
   plot(x=[1:10;], y=rand(10), Geom.bar)

--- a/docs/src/man/themes.md
+++ b/docs/src/man/themes.md
@@ -199,17 +199,17 @@ xs = 0:0.1:20
 
 df_cos = DataFrame(
     x=xs,
-    y=cos(xs),
-    ymin=cos(xs) .- 0.5,
-    ymax=cos(xs) .+ 0.5,
+    y=cos.(xs),
+    ymin=cos.(xs) .- 0.5,
+    ymax=cos.(xs) .+ 0.5,
     f="cos"
 )
 
 df_sin = DataFrame(
     x=xs,
-    y=sin(xs),
-    ymin=sin(xs) .- 0.5,
-    ymax=sin(xs) .+ 0.5,
+    y=sin.(xs),
+    ymin=sin.(xs) .- 0.5,
+    ymax=sin.(xs) .+ 0.5,
     f="sin"
 )
 

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -13,7 +13,7 @@ using Showoff
 
 import Iterators
 import Iterators: distinct, drop, chain
-import Compose: draw, hstack, vstack, gridstack, isinstalled, parse_colorant, parse_colorant_vec
+import Compose: draw, hstack, vstack, gridstack, isinstalled, parse_colorant
 @compat import Base: +, -, /, *,
              copy, push!, start, next, done, show, getindex, cat,
              show, isfinite, display

--- a/src/color_misc.jl
+++ b/src/color_misc.jl
@@ -56,9 +56,7 @@ end
 
 # Then functions return functions suitable for ContinuousColorScales.
 function lab_gradient(cs::Color...)
-    if length(cs) < 2
-        error("Two or more colors are needed for gradients")
-    end
+    length(cs) < 2 && error("Two or more colors are needed for gradients")
 
     cs_lab = [convert(Lab, c) for c in cs]
     n = length(cs_lab)
@@ -70,7 +68,7 @@ function lab_gradient(cs::Color...)
     end
     f
 end
-
+lab_gradient(cs...) = lab_gradient(Gadfly.parse_colorant(cs)...)
 
 function lchabmix(c0_, c1_, r, power)
     c0 = convert(LCHab, c0_)

--- a/src/coord.jl
+++ b/src/coord.jl
@@ -32,11 +32,9 @@ immutable Cartesian <: Gadfly.CoordinateElement
     aspect_ratio::@compat(Union{(@compat Void), Float64})
     raster::Bool
 
-    function Cartesian(xvars, yvars, xmin, xmax, ymin, ymax, xflip, yflip, fixed,
-            aspect_ratio, raster)
-        new(xvars, yvars, xmin, xmax, ymin, ymax, xflip, yflip, fixed,
-            isa(aspect_ratio, Real) ? Float64(aspect_ratio) : aspect_ratio, raster)
-    end
+    Cartesian(xvars, yvars, xmin, xmax, ymin, ymax, xflip, yflip, fixed, aspect_ratio, raster) =
+            new(xvars, yvars, xmin, xmax, ymin, ymax, xflip, yflip, fixed,
+                isa(aspect_ratio, Real) ? Float64(aspect_ratio) : aspect_ratio, raster)
 end
 
 function Cartesian(

--- a/src/geom/hvabline.jl
+++ b/src/geom/hvabline.jl
@@ -1,15 +1,12 @@
-function check_arguments(arg, len)
-    if typeof(arg)<:Vector
-        if length(arg)>1
-            @assert length(arg) == len
-        else
-            arg = fill(arg[1], len)
-        end
+function check_arguments(arg::Vector, len)
+    if length(arg)>1
+        @assert length(arg) == len
     else
-        arg = fill(arg, len)
-    end 
+        arg = fill(arg[1], len)
+    end
     arg
 end
+check_arguments(arg, len) = fill(arg, len)
 
 
 immutable HLineGeometry <: Gadfly.GeometryElement
@@ -18,12 +15,8 @@ immutable HLineGeometry <: Gadfly.GeometryElement
     style::@compat(Union{Vector, Symbol, (@compat Void)})
     tag::Symbol
 
-    function HLineGeometry(color, size, style, tag)
-        new(color === nothing ? nothing :
-                typeof(color)<:Vector ? [parse(Colorant,x) for x in color] :
-                parse(Colorant, color),
-            size, style, tag)
-    end
+    HLineGeometry(color, size, style, tag) =
+            new(color === nothing ? nothing : Gadfly.parse_colorant(color), size, style, tag)
 end
 HLineGeometry(; color=nothing, size=nothing, style=nothing, tag=empty_tag) =
         HLineGeometry(color, size, style, tag)
@@ -64,12 +57,8 @@ immutable VLineGeometry <: Gadfly.GeometryElement
     style::@compat(Union{Vector, Symbol, (@compat Void)})
     tag::Symbol
 
-    function VLineGeometry(color, size, style, tag)
-        new(color === nothing ? nothing :
-                typeof(color)<:Vector ? [parse(Colorant,x) for x in color] :
-                parse(Colorant, color),
-            size, style, tag)
-    end
+    VLineGeometry(color, size, style, tag) =
+            new(color === nothing ? nothing : Gadfly.parse_colorant(color), size, style, tag)
 end
 VLineGeometry(; color=nothing, size=nothing, style=nothing, tag=empty_tag) =
         VLineGeometry(color, size, style, tag)
@@ -110,12 +99,8 @@ immutable ABLineGeometry <: Gadfly.GeometryElement
     style::@compat(Union{Vector, Symbol, (@compat Void)})
     tag::Symbol
 
-    function ABLineGeometry(color, size, style, tag)
-        new(color === nothing ? nothing :
-                typeof(color)<:Vector ? [parse(Colorant,x) for x in color] :
-                parse(Colorant, color),
-            size, style, tag)
-    end
+    ABLineGeometry(color, size, style, tag) =
+            new(color === nothing ? nothing : Gadfly.parse_colorant(color), size, style, tag)
 end
 ABLineGeometry(; color=nothing, size=nothing, style=nothing, tag::Symbol=empty_tag) =
         ABLineGeometry(color, size, style, tag)

--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -30,7 +30,7 @@ path() = LineGeometry(preserve_order=true)
 density(; bandwidth::Real=-Inf) =
     LineGeometry(Gadfly.Stat.density(bandwidth=bandwidth))
 
-density2d(; bandwidth::Real=-Inf, levels=15) =
+density2d(; bandwidth::Tuple{Real,Real}=(-Inf,-Inf), levels=15) =
     LineGeometry(Gadfly.Stat.density2d(bandwidth=bandwidth, levels=levels); preserve_order=true)
 
 smooth(; method::Symbol=:loess, smoothing::Float64=0.75) =

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -32,21 +32,18 @@ end
 
 const nil = Nil
 
-function render(geom::Nil, theme::Gadfly.Theme, aes::Gadfly.Aesthetics,
-                data::Gadfly.Data, scales::Dict{Symbol, ScaleElement},
-                subplot_layer_aess::Vector{Gadfly.Aesthetics})
-end
+render(geom::Nil, theme::Gadfly.Theme, aes::Gadfly.Aesthetics,
+        data::Gadfly.Data, scales::Dict{Symbol, ScaleElement},
+        subplot_layer_aess::Vector{Gadfly.Aesthetics}) = nothing
 
 
 # Subplot geometries require some more arguments to render. A simpler render
 # function is defined and passed through to here for non-subplot geometries.
-function render(geom::Gadfly.GeometryElement, theme::Gadfly.Theme, aes::Gadfly.Aesthetics,
+render(geom::Gadfly.GeometryElement, theme::Gadfly.Theme, aes::Gadfly.Aesthetics,
                 subplot_layer_aess::@compat(Union{(@compat Void), Vector{Gadfly.Aesthetics}}),
                 subplot_layer_datas::@compat(Union{(@compat Void), Vector{Gadfly.Data}}),
-                scales::Dict{Symbol, ScaleElement})
-    render(geom, theme, aes)
-end
-
+                scales::Dict{Symbol, ScaleElement}) =
+        render(geom, theme, aes)
 
 # Catchall
 default_statistic(::Gadfly.GeometryElement) = Gadfly.Stat.identity()

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -44,10 +44,9 @@ end
 
 const background = PanelBackground
 
-function render(guide::Gadfly.GuideElement, theme::Gadfly.Theme,
-                aes::Gadfly.Aesthetics, dynamic::Bool=true)
-    render(guide, theme, aes)
-end
+render(guide::Gadfly.GuideElement, theme::Gadfly.Theme,
+                aes::Gadfly.Aesthetics, dynamic::Bool=true) =
+        render(guide, theme, aes)
 
 function render(guide::PanelBackground, theme::Gadfly.Theme,
                 aes::Gadfly.Aesthetics)
@@ -487,7 +486,7 @@ end
 ManualColorKey{C<:Color}(title, labels, colors::Vector{C}) =
         ManualColorKey{C}(title, labels, colors)
 ManualColorKey(title, labels, colors) =
-        ManualColorKey(title, labels, Gadfly.parse_colorant_vec(colors...))
+        ManualColorKey(title, labels, Gadfly.parse_colorant(colors))
 
 const manual_color_key = ManualColorKey
 

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -14,11 +14,9 @@ import Distributions: Distribution
 
 include("color_misc.jl")
 
-
 # Return true if var is categorical.
 iscategorical(scales::Dict{Symbol, Gadfly.ScaleElement}, var::Symbol) =
         haskey(scales, var) && isa(scales[var], DiscreteScale)
-
 
 # Apply some scales to data in the given order.
 #
@@ -30,9 +28,7 @@ iscategorical(scales::Dict{Symbol, Gadfly.ScaleElement}, var::Symbol) =
 # Returns:
 #   nothing
 #
-function apply_scales(scales,
-                      aess::Vector{Gadfly.Aesthetics},
-                      datas::Gadfly.Data...)
+function apply_scales(scales, aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
     for scale in scales
         apply_scale(scale, aess, datas...)
     end
@@ -41,7 +37,6 @@ function apply_scales(scales,
         aes.titles = data.titles
     end
 end
-
 
 # Apply some scales to data in the given order.
 #
@@ -122,7 +117,6 @@ function ContinuousScale(vars, trans;
     ContinuousScale(vars, trans, minvalue, maxvalue, minticks, maxticks, labels, format, scalable)
 end
 
-
 function make_labeler(scale::ContinuousScale)
     if scale.labels != nothing
         xs -> [scale.labels(x) for x in xs]
@@ -132,7 +126,6 @@ function make_labeler(scale::ContinuousScale)
         xs -> scale.trans.label(xs, scale.format)
     end
 end
-
 
 const x_vars = [:x, :xmin, :xmax, :xintercept, :intercept, :xviewmin, :xviewmax, :xend]
 const y_vars = [:y, :ymin, :ymax, :yintercept, :slope, :middle, :upper_fence, :lower_fence,
@@ -146,7 +139,6 @@ function continuous_scale_partial(vars::Vector{Symbol}, trans::ContinuousScaleTr
                         maxticks=maxticks, scalable=scalable)
     end
 end
-
 
 # Commonly used scales.
 const x_continuous = continuous_scale_partial(x_vars, identity_transform)
@@ -261,13 +253,11 @@ end
 # Reorder the levels of a pooled data array
 function reorder_levels(da::PooledDataArray, order::AbstractVector)
     level_values = levels(da)
-    if length(order) != length(level_values)
-        error("Discrete scale order is not of the same length as the data's levels.")
-    end
+    length(order) != length(level_values) &&
+            error("Discrete scale order is not of the same length as the data's levels.")
     permute!(level_values, order)
     return PooledDataArray(da, level_values)
 end
-
 
 function discretize_make_pda(values::Vector, levels=nothing)
     if levels == nothing
@@ -277,7 +267,6 @@ function discretize_make_pda(values::Vector, levels=nothing)
     end
 end
 
-
 function discretize_make_pda(values::DataArray, levels=nothing)
     if levels == nothing
         return PooledDataArray(values)
@@ -285,7 +274,6 @@ function discretize_make_pda(values::DataArray, levels=nothing)
         return PooledDataArray(convert(DataArray{eltype(levels)}, values), levels)
     end
 end
-
 
 function discretize_make_pda(values::Range, levels=nothing)
     if levels == nothing
@@ -295,7 +283,6 @@ function discretize_make_pda(values::Range, levels=nothing)
     end
 end
 
-
 function discretize_make_pda(values::PooledDataArray, levels=nothing)
     if levels == nothing
         return values
@@ -304,9 +291,7 @@ function discretize_make_pda(values::PooledDataArray, levels=nothing)
     end
 end
 
-
-function discretize(values, levels=nothing, order=nothing,
-                    preserve_order=true)
+function discretize(values, levels=nothing, order=nothing, preserve_order=true)
     if levels == nothing
         if preserve_order
             levels = OrderedSet()
@@ -333,6 +318,7 @@ immutable DiscreteScaleTransform
     f::Function
 end
 
+
 immutable DiscreteScale <: Gadfly.ScaleElement
     vars::Vector{Symbol}
 
@@ -356,7 +342,6 @@ const discrete = DiscreteScale
 
 element_aesthetics(scale::DiscreteScale) = scale.vars
 
-
 x_discrete(; labels=nothing, levels=nothing, order=nothing) =
         DiscreteScale(x_vars, labels=labels, levels=levels, order=order)
 
@@ -372,8 +357,7 @@ shape_discrete(; labels=nothing, levels=nothing, order=nothing) =
 size_discrete(; labels=nothing, levels=nothing, order=nothing) =
         DiscreteScale([:size], labels=labels, levels=levels, order=order)
 
-function apply_scale(scale::DiscreteScale, aess::Vector{Gadfly.Aesthetics},
-                     datas::Gadfly.Data...)
+function apply_scale(scale::DiscreteScale, aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
     for (aes, data) in zip(aess, datas)
         for var in scale.vars
             label_var = Symbol(var, "_label")
@@ -474,13 +458,11 @@ function color_discrete_hue(f=default_discrete_colors;
                             levels=nothing,
                             order=nothing,
                             preserve_order=true)
-
     DiscreteColorScale(
         default_discrete_colors,
         levels=levels,
         order=order,
-        preserve_order=preserve_order,
-    )
+        preserve_order=preserve_order)
 end
 
 @deprecate discrete_color_hue(; levels=nothing, order=nothing, preserve_order=true) color_discrete_hue(; levels=levels, order=order, preserve_order=preserve_order)
@@ -494,9 +476,7 @@ color_discrete_manual(colors::AbstractString...; levels=nothing, order=nothing) 
 
 function color_discrete_manual(colors::Color...; levels=nothing, order=nothing)
     cs = [colors...]
-    f = function(n)
-        distinguishable_colors(n, cs)
-    end
+    f = n -> distinguishable_colors(n, cs)
     DiscreteColorScale(f, levels=levels, order=order)
 end
 
@@ -669,7 +649,8 @@ function apply_scale_typed!(ds, field, scale::ContinuousColorScale,
                             cmin::Float64, cspan::Float64)
     for (i, d) in enumerate(field)
         if isconcrete(d)
-            ds[i] = convert(RGB{Float32}, scale.f((convert(Float64, scale.trans.f(d)) - cmin) / cspan))
+            ds[i] = convert(RGB{Float32},
+                        scale.f((convert(Float64, scale.trans.f(d)) - cmin) / cspan))
         else
             ds[i] = NA
         end

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -490,7 +490,7 @@ const color_discrete = color_discrete_hue
 @deprecate discrete_color(; levels=nothing, order=nothing, preserve_order=true) color_discrete(; levels=levels, order=order, preserve_order=preserve_order)
 
 color_discrete_manual(colors::AbstractString...; levels=nothing, order=nothing) =
-        color_discrete_manual(map(Gadfly.parse_colorant, colors)...; levels=levels, order=order)
+        color_discrete_manual(Gadfly.parse_colorant(colors)...; levels=levels, order=order)
 
 function color_discrete_manual(colors::Color...; levels=nothing, order=nothing)
     cs = [colors...]

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -6,22 +6,16 @@ const label_font_desc = "'PT Sans Caption','Helvetica Neue','Helvetica',sans-ser
 # Choose highlight color by darkening the fill color
 default_discrete_highlight_color(fill_color::Color) = RGB(1, 1, 1)
 
-function default_discrete_highlight_color(fill_color::TransparentColor)
-    return RGBA{Float32}(
-        default_discrete_highlight_color(color(fill_color)),
-        fill_color.alpha)
-end
+default_discrete_highlight_color(fill_color::TransparentColor) = RGBA{Float32}(
+        default_discrete_highlight_color(color(fill_color)), fill_color.alpha)
 
 function default_continuous_highlight_color(fill_color::Color)
     c = convert(LCHab, fill_color)
     return LCHab(max(0, c.l - 40), c.c, c.h)
 end
 
-function default_continuous_highlight_color(fill_color::TransparentColor)
-    return RGBA{Float32}(
-        default_continuous_highlight_color(color(fill_color)),
-        fill_color.alpha)
-end
+default_continuous_highlight_color(fill_color::TransparentColor) = RGBA{Float32}(
+        default_continuous_highlight_color(color(fill_color)), fill_color.alpha)
 
 function default_stroke_color(fill_color::Color)
     fill_color = convert(LCHab, fill_color)
@@ -29,11 +23,8 @@ function default_stroke_color(fill_color::Color)
     LCHab(c.l - 15, c.c, c.h)
 end
 
-function default_stroke_color(fill_color::TransparentColor)
-    return RGBA{Float32}(
-        default_stroke_color(color(fill_color)),
-        fill_color.alpha)
-end
+default_stroke_color(fill_color::TransparentColor) = RGBA{Float32}(
+        default_stroke_color(color(fill_color)), fill_color.alpha)
 
 function default_lowlight_color(fill_color::Color)
     fill_color = convert(LCHab, fill_color)
@@ -41,11 +32,8 @@ function default_lowlight_color(fill_color::Color)
     LCHab(90, 20, c.h)
 end
 
-function default_lowlight_color(fill_color::TransparentColor)
-    return RGBA{Float32}(
-        default_lowlight_color(color(fill_color)),
-        fill_color.alpha)
-end
+default_lowlight_color(fill_color::TransparentColor) = RGBA{Float32}(
+        default_lowlight_color(color(fill_color)), fill_color.alpha)
 
 # Choose a middle color by darkening the fill color
 function default_middle_color(fill_color::Color)
@@ -53,12 +41,8 @@ function default_middle_color(fill_color::Color)
     LCHab(fill_color.l + 40, fill_color.c, fill_color.h)
 end
 
-function default_middle_color(fill_color::TransparentColor)
-    return RGBA{Float32}(
-        default_middle_color(color(fill_color)),
-        fill_color.alpha)
-end
-
+default_middle_color(fill_color::TransparentColor) = RGBA{Float32}(
+        default_middle_color(color(fill_color)), fill_color.alpha)
  
 get_stroke_vector(::@compat(Void)) = []
 get_stroke_vector(vec::AbstractVector) = vec
@@ -73,7 +57,6 @@ function get_stroke_vector(linestyle::Symbol)
   linestyle == :dashdotdot && return [dash, gap, dot, gap, dot, gap]
   error("unsupported linestyle: ", linestyle)
 end
-
 
 @varset Theme begin
     # If the color aesthetic is not mapped to anything, this is the color that
@@ -265,10 +248,7 @@ Go back to using the previous theme
 See also `push_theme` and `with_theme`
 """
 function pop_theme()
-    if length(theme_stack) == 1
-        error("There default theme cannot be removed")
-    end
-
+    length(theme_stack) == 1 && error("There default theme cannot be removed")
     pop!(theme_stack)
 end
 

--- a/src/varset.jl
+++ b/src/varset.jl
@@ -7,6 +7,7 @@ macro varset(name::Symbol, table)
 
     names = Any[]
     vars = Any[]
+    parsed_vars = Any[]
     parameters = Any[]
     parameters_expr = Expr(:parameters)
     inherit_parameters = Any[]
@@ -34,6 +35,11 @@ macro varset(name::Symbol, table)
         push!(vars, :($(var)::$(typ)))
         push!(parameters, Expr(:kw, var, default))
         push!(inherit_parameters, Expr(:kw, var, :(b.$var)))
+        if typ==:ColorOrNothing
+            push!(parsed_vars, :($(var)==nothing ? nothing : parse_colorant($(var))))
+        else
+            push!(parsed_vars, :($(var)))
+        end
     end
 
     parameters_expr = Expr(:parameters, parameters...)
@@ -45,7 +51,7 @@ macro varset(name::Symbol, table)
             $(vars...)
         end
 
-        $(name)($(parameters_expr)) = $(name)($(names...))
+        $(name)($(parameters_expr)) = $(name)($(parsed_vars...))
         $(name)($(inherit_parameters_expr), b::$name) = $(name)($(names...))
         copy(a::$(name)) = $(name)(a)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,7 @@ tests = [
     ("histogram2d",                           6inch, 3inch),
     ("rectbin",                               6inch, 3inch),
     ("density",                               6inch, 3inch),
+    ("density2d",                             6inch, 3inch),
     ("density_dark",                          6inch, 3inch),
     ("colorful_density",                      6inch, 3inch),
     ("explicit_colorkey_title",               6inch, 3inch),


### PR DESCRIPTION
standard strings can now be used in all color fields of `Theme`.  they're automatically parsed with `parse(Colorant...`.  for example, `Theme(default_color=colorant"red")` becomes `Theme(default_color="red")`.