### PR TITLE
Add DataArrays to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,6 +5,7 @@ Compose 0.5.1
 Contour 0.1.1
 CoupledFields
 DataFrames 0.4.2
+DataArrays
 DataStructures
 Distributions
 Hexagons


### PR DESCRIPTION
since it's used directly in src, it should be explicitly listed in REQUIRE
rather than assuming it will be present as a transitive dependency

(e.g. if there were to be some future version of DataFrames that did not depend on DataArrays)