### PR TITLE
fix test/errorbar.jl

### DIFF
--- a/test/errorbar.jl
+++ b/test/errorbar.jl
@@ -1,4 +1,3 @@
-
 using Gadfly
 using RDatasets
 using Distributions
@@ -10,6 +9,7 @@ ymins = ys .- (1.96 * sds / sqrt(n))
 ymaxs = ys .+ (1.96 * sds / sqrt(n))
 cs = [string(i) for i in 1:length(sds)]
 
-plot(x=1:length(sds),
-    x=ys, xmin=ymins, xmax=ymaxs,
-    y=ys, ymin=ymins, ymax=ymaxs, color=cs, Geom.point, Geom.errorbar)
+plot(x=ys, xmin=ymins, xmax=ymaxs,
+     y=ys, ymin=ymins, ymax=ymaxs,
+     color=cs,
+     Geom.point, Geom.errorbar)


### PR DESCRIPTION
julia 0.7 throws an error when keyword args are multiply defined