### PR TITLE
fix docs/geom_rectbin

### DIFF
--- a/docs/src/lib/geoms/geom_rectbin.md
+++ b/docs/src/lib/geoms/geom_rectbin.md
@@ -30,7 +30,7 @@ positions.
 
 ```@setup 1
 using DataFrames, RDatasets
-using Gadfly
+using Gadfly, Colors
 Gadfly.set_default_plot_size(14cm, 8cm)
 ```
 


### PR DESCRIPTION
travis seemingly doesn't report documenter.jl errors