### PR TITLE
two fixes for Geom.bar

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -386,9 +386,9 @@ function render_prepare(plot::Plot)
     # putting the layers in one subplot instead.
     if sum([isa(layer.geom, Geom.SubplotGeometry) for layer in plot.layers]) > 1
         error("""
-            Subplot geometries can not be used in multiple layers. Instead
-            use layers within one subplot geometry.
-            """)
+              Subplot geometries can not be used in multiple layers. Instead
+              use layers within one subplot geometry.
+              """)
     end
 
     # Process layers, filling inheriting mappings or data from the Plot where
@@ -479,10 +479,8 @@ function render_prepare(plot::Plot)
         union!(used_aesthetics, element_aesthetics(layer.geom))
     end
 
-    for stats in layer_stats
-        for stat in stats
-            union!(used_aesthetics, input_aesthetics(stat))
-        end
+    for stats in layer_stats, stat in stats
+        union!(used_aesthetics, input_aesthetics(stat))
     end
 
     mapped_aesthetics = Set(keys(plot.mapping))
@@ -492,8 +490,8 @@ function render_prepare(plot::Plot)
 
     defined_unused_aesthetics = setdiff(mapped_aesthetics, used_aesthetics)
     isempty(defined_unused_aesthetics) ||
-        warn("The following aesthetics are mapped, but not used by any geometry:\n",
-                 join([string(a) for a in defined_unused_aesthetics], ", "))
+            warn("The following aesthetics are mapped, but not used by any geometry:\n",
+                join([string(a) for a in defined_unused_aesthetics], ", "))
 
     scaled_aesthetics = Set{Symbol}()
     for scale in plot.scales

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -450,8 +450,8 @@ function render_prepare(plot::Plot)
     # Add default statistics for geometries.
     layer_stats = Array{Vector{StatisticElement}}(length(plot.layers))
     for (i, layer) in enumerate(plot.layers)
-        layer_stats[i] = isempty(layer.statistics) ?
-            [default_statistic(layer.geom)] : layer.statistics
+        layer_stats[i] = isempty(layer.statistics) ? ( isa(layer.geom, Geom.SubplotGeometry) ?
+                default_statistic(layer.geom) : [default_statistic(layer.geom)] ) : layer.statistics
     end
 
     # auto-enumeration: add Stat.x/y_enumerate when x and y is needed but only
@@ -464,10 +464,11 @@ function render_prepare(plot::Plot)
             union!(layer_defined_aes, output_aesthetics(stat))
         end
 
-        if :x in layer_needed_aes && :y in layer_needed_aes
-            if !(:x in layer_defined_aes)
+        if mapreduce(x->in(x,layer_needed_aes),|,[:x,:xmax,:xmin]) &&
+                mapreduce(y->in(y,layer_needed_aes),|,[:y,:ymax,:ymin])
+            if !mapreduce(x->in(x,layer_defined_aes),|,[:x,:xmax,:xmin])
                 unshift!(layer_stats[i], Stat.x_enumerate)
-            elseif !(:y in layer_defined_aes)
+            elseif !mapreduce(y->in(y,layer_defined_aes),|,[:y,:ymax,:ymin])
                 unshift!(layer_stats[i], Stat.y_enumerate)
             end
         end

--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -132,9 +132,7 @@ getindex(aes::Aesthetics, i::Integer, j::AbstractString) = getfield(aes, Symbol(
 function defined_aesthetics(aes::Aesthetics)
     vars = Set{Symbol}()
     for name in fieldnames(Aesthetics)
-        if getfield(aes, name) !== nothing
-            push!(vars, name)
-        end
+        getfield(aes, name) === nothing || push!(vars, name)
     end
     vars
 end
@@ -258,10 +256,8 @@ function cat_aes_var!(a::Dict, b::Dict)
 end
 
 cat_aes_var!{T <: Base.Callable}(a::AbstractArray{T}, b::AbstractArray{T}) = append!(a, b)
-
-function cat_aes_var!{T <: Base.Callable, U <: Base.Callable}(a::AbstractArray{T}, b::AbstractArray{U})
-    a=[promote(a..., b...)...]
-end
+cat_aes_var!{T <: Base.Callable, U <: Base.Callable}(a::AbstractArray{T}, b::AbstractArray{U}) =
+        a=[promote(a..., b...)...]
 
 # Let arrays of numbers clobber arrays of functions. This is slightly odd
 # behavior, comes up with with function statistics applied on a layer-wise
@@ -321,8 +317,7 @@ end
 #
 function by_xy_group{T <: @compat(Union{Data, Aesthetics})}(aes::T, xgroup, ygroup,
                                                    num_xgroups, num_ygroups)
-    @assert xgroup === nothing || ygroup === nothing ||
-            length(xgroup) == length(ygroup)
+    @assert xgroup === nothing || ygroup === nothing || length(xgroup) == length(ygroup)
 
     n = num_ygroups
     m = num_xgroups
@@ -336,16 +331,12 @@ function by_xy_group{T <: @compat(Union{Data, Aesthetics})}(aes::T, xgroup, ygro
         aes_grid[i, j] = T()
     end
 
-    if xgroup === nothing && ygroup === nothing
-        return aes_grid
-    end
+    xgroup === nothing && ygroup === nothing && return aes_grid
 
-    function make_pooled_data_array{T, U, V}(::Type{PooledDataArray{T,U,V}},
-                                             arr::AbstractArray)
-        PooledDataArray(convert(Array{T}, arr))
-    end
-    make_pooled_data_array{T, U, V}(::Type{PooledDataArray{T,U,V}},
-                                    arr::PooledDataArray{T, U, V}) = arr
+    make_pooled_data_array{T,U,V}(::Type{PooledDataArray{T,U,V}}, arr::AbstractArray) =
+            PooledDataArray(convert(Array{T}, arr))
+    make_pooled_data_array{T,U,V}(::Type{PooledDataArray{T,U,V}},
+            arr::PooledDataArray{T,U,V}) = arr
 
     for var in fieldnames(T)
         # Skipped aesthetics. Don't try to partition aesthetics for which it
@@ -419,13 +410,9 @@ function inherit!(a::Aesthetics, b::Aesthetics;
         elseif aval === nothing || aval === string || aval == showoff
             setfield!(a, field, bval)
         elseif field == :xviewmin || field == :yviewmin
-            if bval != nothing && (aval == nothing || aval > bval)
-                setfield!(a, field, bval)
-            end
+            bval != nothing && (aval == nothing || aval > bval) && setfield!(a, field, bval)
         elseif field == :xviewmax || field == :yviewmax
-            if bval != nothing && (aval == nothing || aval < bval)
-                setfield!(a, field, bval)
-            end
+            bval != nothing && (aval == nothing || aval < bval) && setfield!(a, field, bval)
         elseif typeof(aval) <: Dict && typeof(bval) <: Dict
             merge!(aval, getfield(b, field))
         end

--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -363,7 +363,7 @@ function by_xy_group{T <: @compat(Union{Data, Aesthetics})}(aes::T, xgroup, ygro
         if typeof(vals) <: AbstractArray
             if xgroup !== nothing && length(vals) !== length(xgroup) ||
                ygroup !== nothing && length(vals) !== length(ygroup)
-                error("Aesthetic $(var) must be the same length as xgroup or ygroup")
+                continue
             end
 
             for i in 1:n, j in 1:m

--- a/src/geom/bar.jl
+++ b/src/geom/bar.jl
@@ -37,7 +37,8 @@ function histogram(; position=:stack, bincount=nothing,
         tag)
 end
 
-element_aesthetics(::BarGeometry) = [:x, :xmin, :xmax, :y, :ymin, :ymax, :color]
+element_aesthetics(geom::BarGeometry) = geom.orientation == :vertical ?
+            [:xmin, :xmax, :y, :color] : [:ymin, :ymax, :x, :color]
 
 default_statistic(geom::BarGeometry) = geom.default_statistic
 
@@ -262,15 +263,9 @@ function render(geom::BarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     if geom.orientation == :horizontal
         Gadfly.assert_aesthetics_defined("BarGeometry", aes, :ymin, :ymax, :x)
         Gadfly.assert_aesthetics_equal_length("BarGeometry", aes, :ymin, :ymax, :x)
-        var = :y
-        minvar = :ymin
-        maxvar = :ymax
     else
         Gadfly.assert_aesthetics_defined("BarGeometry", aes, :xmin, :xmax, :y)
         Gadfly.assert_aesthetics_equal_length("BarGeometry", aes, :xmin, :xmax, :y)
-        var = :x
-        minvar = :xmin
-        maxvar = :xmax
     end
 
     if aes.color === nothing

--- a/src/geom/bar.jl
+++ b/src/geom/bar.jl
@@ -96,11 +96,14 @@ function render_colorful_stacked_bar(geom::BarGeometry,
             stack_height_dict[aes.ymin[j]] += aes.x[j]
         end
 
-        compose!(ctx,
-            rectangle(stack_height,
-                [aes.ymin[i]*cy + theme.bar_spacing/2 for i in idxs],
-                [aes.x[i] for i in idxs],
-                [(aes.ymax[i] - aes.ymin[i])*cy - theme.bar_spacing for i in idxs], geom.tag))
+        x0s = stack_height
+        y0s = [aes.ymin[i]*cy + theme.bar_spacing/2 for i in idxs]
+        widths = [abs(aes.x[i]) for i in idxs]
+        heights = [(aes.ymax[i] - aes.ymin[i])*cy - theme.bar_spacing for i in idxs]
+        if any(aes.x .< 0)
+          x0s -= widths
+        end
+        compose!(ctx, rectangle(x0s, y0s, widths, heights, geom.tag))
     else
         stack_height_dict = Dict()
         T = eltype(aes.y)
@@ -115,11 +118,14 @@ function render_colorful_stacked_bar(geom::BarGeometry,
             stack_height_dict[aes.xmin[j]] += aes.y[j]
         end
 
-        compose!(ctx,
-            rectangle([aes.xmin[i]*cx + theme.bar_spacing/2 for i in idxs],
-                stack_height,
-                [(aes.xmax[i] - aes.xmin[i])*cx - theme.bar_spacing for i in idxs],
-                [aes.y[i] for i in idxs], geom.tag))
+        x0s = [aes.xmin[i]*cx + theme.bar_spacing/2 for i in idxs]
+        y0s = stack_height
+        widths = [(aes.xmax[i] - aes.xmin[i])*cx - theme.bar_spacing for i in idxs]
+        heights = [abs(aes.y[i]) for i in idxs]
+        if any(aes.y .< 0)
+          y0s -= heights
+        end
+        compose!(ctx, rectangle(x0s, y0s, widths, heights, geom.tag))
     end
 
     cs = [aes.color[i] for i in idxs]

--- a/src/geom/bar.jl
+++ b/src/geom/bar.jl
@@ -1,33 +1,22 @@
 # Bar geometry summarizes data as vertical bars.
 immutable BarGeometry <: Gadfly.GeometryElement
-    # How bars should be positioned if they are grouped by color.
-    # Valid options are:
-    #   :stack -> place bars on top of each other (default)
-    #   :dodge -> place bar next to each other
-    position::Symbol
-
-    # :vertical or :horizontal
-    orientation::Symbol
-
+    position::Symbol  # :stack (default) or :dodge
+    orientation::Symbol # :vertical (default) or :horizontal
     default_statistic::Gadfly.StatisticElement
-
     tag::Symbol
 end
-
-function BarGeometry(; position=:stack, orientation=:vertical, tag=empty_tag)
-    BarGeometry(position, orientation, Gadfly.Stat.bar(position=position,
-        orientation = orientation), tag)
-end
+BarGeometry(; position=:stack, orientation=:vertical, tag=empty_tag) =
+        BarGeometry(position, orientation, Gadfly.Stat.bar(position=position,
+            orientation = orientation), tag)
 
 const bar = BarGeometry
 
-function histogram(; position=:stack, bincount=nothing,
+histogram(; position=:stack, bincount=nothing,
                    minbincount=3, maxbincount=150,
                    orientation::Symbol=:vertical,
                    density::Bool=false,
-                   tag::Symbol=empty_tag)
-    return BarGeometry(
-        position, orientation,
+                   tag::Symbol=empty_tag) =
+    BarGeometry(position, orientation,
         Gadfly.Stat.histogram(bincount=bincount,
                               minbincount=minbincount,
                               maxbincount=maxbincount,
@@ -35,7 +24,6 @@ function histogram(; position=:stack, bincount=nothing,
                               orientation=orientation,
                               density=density),
         tag)
-end
 
 element_aesthetics(geom::BarGeometry) = geom.orientation == :vertical ?
             [:xmin, :xmax, :y, :color] : [:ymin, :ymax, :x, :color]
@@ -50,8 +38,7 @@ function render_colorless_bar(geom::BarGeometry,
     if orientation == :horizontal
         XT = eltype(aes.x)
         xz = convert(XT, zero(XT))
-        ctx = compose!(
-            context(),
+        ctx = compose!(context(),
             rectangle([min(xz, x) for x in aes.x],
                       [ymin*cy + theme.bar_spacing/2 for ymin in aes.ymin],
                       abs.(aes.x),
@@ -61,8 +48,7 @@ function render_colorless_bar(geom::BarGeometry,
     else
         YT = eltype(aes.y)
         yz = convert(YT, zero(YT))
-        ctx = compose!(
-            context(),
+        ctx = compose!(context(),
             rectangle([xmin*cx + theme.bar_spacing/2 for xmin in aes.xmin],
                       [min(yz, y) for y in aes.y],
                       [(xmax - xmin)*cx - theme.bar_spacing
@@ -110,14 +96,12 @@ function render_colorful_stacked_bar(geom::BarGeometry,
             stack_height_dict[aes.ymin[j]] += aes.x[j]
         end
 
-        compose!(
-            ctx,
-            rectangle(
-                stack_height,
+        compose!(ctx,
+            rectangle(stack_height,
                 [aes.ymin[i]*cy + theme.bar_spacing/2 for i in idxs],
                 [aes.x[i] for i in idxs],
                 [(aes.ymax[i] - aes.ymin[i])*cy - theme.bar_spacing for i in idxs], geom.tag))
-    elseif orientation == :vertical
+    else
         stack_height_dict = Dict()
         T = eltype(aes.y)
         z = convert(T, zero(T))
@@ -131,15 +115,11 @@ function render_colorful_stacked_bar(geom::BarGeometry,
             stack_height_dict[aes.xmin[j]] += aes.y[j]
         end
 
-        compose!(
-            ctx,
-            rectangle(
-                [aes.xmin[i]*cx + theme.bar_spacing/2 for i in idxs],
+        compose!(ctx,
+            rectangle([aes.xmin[i]*cx + theme.bar_spacing/2 for i in idxs],
                 stack_height,
                 [(aes.xmax[i] - aes.xmin[i])*cx - theme.bar_spacing for i in idxs],
                 [aes.y[i] for i in idxs], geom.tag))
-    else
-        error("Orientation must be :horizontal or :vertical")
     end
 
     cs = [aes.color[i] for i in idxs]
@@ -192,15 +172,13 @@ function render_colorful_dodged_bar(geom::BarGeometry,
         xz = convert(XT, zero(XT))
 
         aes_x = aes.x[idxs]
-        compose!(
-            ctx,
-            rectangle(
-                [min(xz, x) for x in aes_x],
+        compose!(ctx,
+            rectangle([min(xz, x) for x in aes_x],
                 dodge_pos,
                 abs.(aes_x),
                 [((aes.ymax[i] - aes.ymin[i])*cy - theme.bar_spacing) / dodge_count[aes.ymin[i]]
                  for i in idxs], geom.tag))
-    elseif orientation == :vertical
+    else
         dodge_count = DefaultDict(() -> 0)
         for i in idxs
             dodge_count[aes.xmin[i]] += 1
@@ -224,16 +202,12 @@ function render_colorful_dodged_bar(geom::BarGeometry,
         yz = convert(YT, zero(YT))
 
         aes_y = aes.y[idxs]
-        compose!(
-            ctx,
-            rectangle(
-                dodge_pos,
+        compose!(ctx,
+            rectangle(dodge_pos,
                 [min(yz, y) for y in aes_y],
                 [((aes.xmax[i] - aes.xmin[i])*cx - theme.bar_spacing) / dodge_count[aes.xmin[i]]
                  for i in idxs],
                 abs.(aes_y), geom.tag))
-    else
-        error("Orientation must be :horizontal or :vertical")
     end
 
     cs = [aes.color[i] for i in idxs]
@@ -263,9 +237,11 @@ function render(geom::BarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     if geom.orientation == :horizontal
         Gadfly.assert_aesthetics_defined("BarGeometry", aes, :ymin, :ymax, :x)
         Gadfly.assert_aesthetics_equal_length("BarGeometry", aes, :ymin, :ymax, :x)
-    else
+    elseif geom.orientation == :vertical
         Gadfly.assert_aesthetics_defined("BarGeometry", aes, :xmin, :xmax, :y)
         Gadfly.assert_aesthetics_equal_length("BarGeometry", aes, :xmin, :xmax, :y)
+    else
+        error("Orientation must be :horizontal or :vertical")
     end
 
     if aes.color === nothing
@@ -278,9 +254,7 @@ function render(geom::BarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
         error("$(geom.position) is not a valid position for the bar geometry.")
     end
 
-    return compose!(
-        context(),
-        ctx,
+    return compose!(context(), ctx,
         linewidth(theme.highlight_width),
         svgattribute("shape-rendering", "crispEdges"))
 end

--- a/src/geom/subplot.jl
+++ b/src/geom/subplot.jl
@@ -37,13 +37,10 @@ end
 
 add_subplot_element(subplot::SubplotGeometry, arg::Gadfly.GuideElement) =
         subplot.guides[typeof(arg)] = arg
-
 add_subplot_element{T <: Gadfly.Element}(subplot::SubplotGeometry, arg::Type{T}) =
         add_subplot_element(subplot, arg())
-
 add_subplot_element(subplot::SubplotGeometry, coord::Gadfly.CoordinateElement) =
         subplot.coord = coord
-
 add_subplot_element(subplot::SubplotGeometry, arg) =
         error("Subplots do not support elements of type $(typeof(arg))")
 
@@ -150,8 +147,8 @@ function render(geom::SubplotGrid, theme::Gadfly.Theme,
     coord = geom.coord
     plot_stats = Gadfly.StatisticElement[stat for stat in geom.statistics]
     layer_stats = [isempty(layer.statistics) ?
-                        Gadfly.StatisticElement[Geom.default_statistic(layer.geom)] : layer.statistics
-                   for layer in geom.layers]
+            Gadfly.StatisticElement[Geom.default_statistic(layer.geom)] : layer.statistics
+                for layer in geom.layers]
 
     for i in 1:n, j in 1:m
         Scale.apply_scales(geom.scales,
@@ -186,13 +183,8 @@ function render(geom::SubplotGrid, theme::Gadfly.Theme,
         end
     end
 
-    if !geom.free_x_axis && !has_stat_xticks
-        push!(geom_stats, Stat.xticks())
-    end
-
-    if !geom.free_y_axis && !has_stat_yticks
-        push!(geom_stats, Stat.yticks())
-    end
+    !geom.free_x_axis && !has_stat_xticks && push!(geom_stats, Stat.xticks())
+    !geom.free_y_axis && !has_stat_yticks && push!(geom_stats, Stat.yticks())
 
     Stat.apply_statistics(geom_stats, scales, coord, geom_aes)
     aes_grid = [geom_aes for i in 1:n, j in 1:m]

--- a/src/geom/subplot.jl
+++ b/src/geom/subplot.jl
@@ -101,6 +101,10 @@ end
 
 element_coordinate_type(::SubplotGrid) = Gadfly.Coord.subplot_grid
 
+default_statistic(geom::SubplotGrid) = isempty(geom.statistics) ?
+        [default_statistic(l.geom) for l in geom.layers] : geom.statistics
+
+
 # Render a subplot grid geometry, which consists of rendering and arranging
 # many smaller plots.
 function render(geom::SubplotGrid, theme::Gadfly.Theme,

--- a/src/mapping.jl
+++ b/src/mapping.jl
@@ -60,9 +60,7 @@ function cleanmapping(mapping::Dict)
     cleaned = Dict{Symbol, Any}()
     for (key, val) in mapping
         # skip the "order" pesudo-aesthetic, used to order layers
-        if key == :order
-            continue
-        end
+        key == :order && continue
 
         if haskey(aesthetic_aliases, key)
             key = aesthetic_aliases[key]
@@ -250,22 +248,20 @@ function meltdata(U::AbstractMatrix, colgroups_::Vector{Col.GroupedColumn})
                for colgroup in colgroups]
 
     vi = 1
-    for ui in 1:um
-        for colidx in IterTools.product(colidxs...)
-            # copy grouped columns
-            for (vj, uj) in enumerate(colidx)
-                V[vi, vj] = U[ui, uj]
-                col_indicators[vi, vj] = uj
-                row_indicators[vi, vj] = ui
-            end
-
-            # copy ungrouped columns
-            for (vj, uj) in enumerate(ungrouped_columns)
-                V[vi, vj + length(colgroups)] = U[ui, uj]
-            end
-
-            vi += 1
+    for ui in 1:um, colidx in IterTools.product(colidxs...)
+        # copy grouped columns
+        for (vj, uj) in enumerate(colidx)
+            V[vi, vj] = U[ui, uj]
+            col_indicators[vi, vj] = uj
+            row_indicators[vi, vj] = ui
         end
+
+        # copy ungrouped columns
+        for (vj, uj) in enumerate(ungrouped_columns)
+            V[vi, vj + length(colgroups)] = U[ui, uj]
+        end
+
+        vi += 1
     end
 
     # Map grouped and individual columns in U to columns in V

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -336,7 +336,7 @@ function apply_statistic(stat::HistogramStatistic,
             for x in xs
                 Gadfly.isconcrete(x) || continue
                 if isdiscrete
-                    bincounts[int(x)] += 1
+                    bincounts[round(Int,x)] += 1
                 else
                     bin = max(1, min(d, (@compat ceil(Int, (x - x_min) / binwidth))))
                     bincounts[bin] += 1

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -42,20 +42,16 @@ function apply_statistics(stats::Vector{Gadfly.StatisticElement},
     nothing
 end
 
-immutable Nil <: Gadfly.StatisticElement
-end
+immutable Nil <: Gadfly.StatisticElement end
 
 const nil = Nil
 
-immutable Identity <: Gadfly.StatisticElement
-end
+immutable Identity <: Gadfly.StatisticElement end
 
-function apply_statistic(stat::Identity,
-                         scales::Dict{Symbol, Gadfly.ScaleElement},
-                         coord::Gadfly.CoordinateElement,
-                         aes::Gadfly.Aesthetics)
-    nothing
-end
+apply_statistic(stat::Identity,
+                scales::Dict{Symbol, Gadfly.ScaleElement},
+                coord::Gadfly.CoordinateElement,
+                aes::Gadfly.Aesthetics) = nothing
 
 const identity = Identity
 
@@ -92,8 +88,7 @@ function barminmax(values, iscontinuous::Bool)
 end
 
 
-immutable RectbinStatistic <: Gadfly.StatisticElement
-end
+immutable RectbinStatistic <: Gadfly.StatisticElement end
 
 const rectbin = RectbinStatistic
 
@@ -136,13 +131,8 @@ input_aesthetics(stat::BarStatistic) = stat.orientation == :vertical ? [:x] : [:
 output_aesthetics(stat::BarStatistic) =
     stat.orientation == :vertical ? [:xmin, :xmax] : [:ymin, :ymax]
 
-function default_scales(stat::BarStatistic)
-    if stat.orientation == :vertical
-        return [Gadfly.Scale.y_continuous()]
-    else
-        return [Gadfly.Scale.x_continuous()]
-    end
-end
+default_scales(stat::BarStatistic) = stat.orientation == :vertical ?
+        [Gadfly.Scale.y_continuous()] : [Gadfly.Scale.x_continuous()]
 
 const bar = BarStatistic
 
@@ -234,13 +224,8 @@ input_aesthetics(stat::HistogramStatistic) = stat.orientation == :vertical ? [:x
 output_aesthetics(stat::HistogramStatistic) =
     stat.orientation == :vertical ? [:x, :y, :xmin, :xmax] : [:y, :x, :ymin, :ymax]
 
-function default_scales(stat::HistogramStatistic)
-    if stat.orientation == :vertical
-        return [Gadfly.Scale.y_continuous()]
-    else
-        return [Gadfly.Scale.x_continuous()]
-    end
-end
+default_scales(stat::HistogramStatistic) = stat.orientation == :vertical ?
+        [Gadfly.Scale.y_continuous()] : [Gadfly.Scale.x_continuous()]
 
 const histogram = HistogramStatistic
 
@@ -269,9 +254,7 @@ function apply_statistic(stat::HistogramStatistic,
     Gadfly.assert_aesthetics_defined("HistogramStatistic", aes, var)
 
     values = getfield(aes, var)
-    if stat.minbincount > stat.maxbincount
-        error("Histogram minbincount > maxbincount")
-    end
+    stat.minbincount > stat.maxbincount && error("Histogram minbincount > maxbincount")
 
     if isempty(getfield(aes, var))
         setfield!(aes, minvar, Float64[1.0])
@@ -330,9 +313,7 @@ function apply_statistic(stat::HistogramStatistic,
     else
         groups = Dict()
         for (x, c) in zip(values, cycle(aes.color))
-            if !Gadfly.isconcrete(x)
-                continue
-            end
+            Gadfly.isconcrete(x) || continue
 
             if !haskey(groups, c)
                 groups[c] = Float64[x]
@@ -353,9 +334,7 @@ function apply_statistic(stat::HistogramStatistic,
         for (i, (c, xs)) in enumerate(groups)
             fill!(bincounts, 0)
             for x in xs
-                if !Gadfly.isconcrete(x)
-                    continue
-                end
+                Gadfly.isconcrete(x) || continue
                 if isdiscrete
                     bincounts[int(x)] += 1
                 else
@@ -493,9 +472,7 @@ function apply_statistic(stat::DensityStatistic,
     Gadfly.assert_aesthetics_defined("DensityStatistic", aes, :x)
 
     if aes.color === nothing
-        if !isa(aes.x[1], Real)
-            error("Kernel density estimation only works on Real types.")
-        end
+        isa(aes.x[1], Real) || error("Kernel density estimation only works on Real types.")
 
         x_f64 = collect(Float64, aes.x)
 
@@ -645,13 +622,10 @@ function apply_statistic(stat::Histogram2DStatistic,
     end
     @assert k - 1 == n
 
-    if !haskey(scales, :color)
-        error("Histogram2DStatistic requires a color scale.")
-    end
+    haskey(scales, :color) || error("Histogram2DStatistic requires a color scale.")
     color_scale = scales[:color]
-    if !(typeof(color_scale) <: Scale.ContinuousColorScale)
-        error("Histogram2DStatistic requires a continuous color scale.")
-    end
+    typeof(color_scale) <: Scale.ContinuousColorScale ||
+            error("Histogram2DStatistic requires a continuous color scale.")
 
     aes.color_key_title = "Count"
 
@@ -698,30 +672,24 @@ end
 
 @deprecate xticks(ticks) xticks(ticks=ticks)
 
-function xticks(; ticks=:auto,
-                  granularity_weight=1/4,
-                  simplicity_weight=1/6,
-                  coverage_weight=1/3,
-                  niceness_weight=1/4)
+xticks(; ticks=:auto,
+         granularity_weight=1/4,
+         simplicity_weight=1/6,
+         coverage_weight=1/3,
+         niceness_weight=1/4) = 
     TickStatistic([:x, :xmin, :xmax, :xintercept], "x",
-                  granularity_weight, simplicity_weight,
-                  coverage_weight, niceness_weight, ticks)
-end
-
+              granularity_weight, simplicity_weight, coverage_weight, niceness_weight, ticks)
 
 @deprecate yticks(ticks) yticks(ticks=ticks)
 
-function yticks(; ticks=:auto,
-                  granularity_weight=1/4,
-                  simplicity_weight=1/6,
-                  coverage_weight=1/3,
-                  niceness_weight=1/4)
-    TickStatistic(
-        [:y, :ymin, :ymax, :yintercept, :middle, :lower_hinge, :upper_hinge,
-         :lower_fence, :upper_fence], "y",
-        granularity_weight, simplicity_weight,
-        coverage_weight, niceness_weight, ticks)
-end
+yticks(; ticks=:auto,
+         granularity_weight=1/4,
+         simplicity_weight=1/6,
+         coverage_weight=1/3,
+         niceness_weight=1/4) =
+    TickStatistic([:y, :ymin, :ymax, :yintercept, :middle, :lower_hinge, :upper_hinge,
+        :lower_fence, :upper_fence], "y",
+        granularity_weight, simplicity_weight, coverage_weight, niceness_weight, ticks)
 
 # Apply a tick statistic.
 #
@@ -861,13 +829,12 @@ function apply_statistic(stat::TickStatistic,
     else
         minval, maxval = promote(minval, maxval)
 
-        ticks, viewmin, viewmax =
-            Gadfly.optimize_ticks(minval, maxval, extend_ticks=true,
-                                  granularity_weight=stat.granularity_weight,
-                                  simplicity_weight=stat.simplicity_weight,
-                                  coverage_weight=stat.coverage_weight,
-                                  niceness_weight=stat.niceness_weight,
-                                  strict_span=strict_span)
+        ticks, viewmin, viewmax = Gadfly.optimize_ticks(minval, maxval, extend_ticks=true,
+                granularity_weight=stat.granularity_weight,
+                simplicity_weight=stat.simplicity_weight,
+                coverage_weight=stat.coverage_weight,
+                niceness_weight=stat.niceness_weight,
+                strict_span=strict_span)
         grids = ticks
         multiticks = Gadfly.multilevel_ticks(viewmin - (viewmax - viewmin),
                                              viewmax + (viewmax - viewmin))
@@ -881,13 +848,11 @@ function apply_statistic(stat::TickStatistic,
             i += 1
         end
 
-        for (scale, ts) in multiticks
-            for t in ts
-                push!(ticks, t)
-                tickvisible[i] = false
-                tickscale[i] = scale
-                i += 1
-            end
+        for (scale, ts) in multiticks, t in ts
+            push!(ticks, t)
+            tickvisible[i] = false
+            tickscale[i] = scale
+            i += 1
         end
     end
 
@@ -902,14 +867,12 @@ function apply_statistic(stat::TickStatistic,
     setfield!(aes, Symbol(stat.out_var, "tickscale"), tickscale)
 
     viewmin_var = Symbol(stat.out_var, "viewmin")
-    if getfield(aes, viewmin_var) === nothing ||
-       getfield(aes, viewmin_var) > viewmin
+    if getfield(aes, viewmin_var) === nothing || getfield(aes, viewmin_var) > viewmin
         setfield!(aes, viewmin_var, viewmin)
     end
 
     viewmax_var = Symbol(stat.out_var, "viewmax")
-    if getfield(aes, viewmax_var) === nothing ||
-       getfield(aes, viewmax_var) < viewmax
+    if getfield(aes, viewmax_var) === nothing || getfield(aes, viewmax_var) < viewmax
         setfield!(aes, viewmax_var, viewmax)
     end
 
@@ -969,8 +932,7 @@ function minvalmaxval{T}(minval::T, maxval::T, val, s, ds)
 end
 
 
-immutable BoxplotStatistic <: Gadfly.StatisticElement
-end
+immutable BoxplotStatistic <: Gadfly.StatisticElement end
 
 input_aesthetics(stat::BoxplotStatistic) = [:x, :y]
 output_aesthetics(stat::BoxplotStatistic) =
@@ -1093,71 +1055,66 @@ function apply_statistic(stat::SmoothStatistic,
     Gadfly.assert_aesthetics_defined("Stat.smooth", aes, :x, :y)
     Gadfly.assert_aesthetics_equal_length("Stat.smooth", aes, :x, :y)
 
-    if !(stat.method in [:loess,:lm])
-        error("The only Stat.smooth methods currently supported are loess and lm.")
-    end
+    stat.method in [:loess,:lm] ||
+            error("The only Stat.smooth methods currently supported are loess and lm.")
 
     max_num_steps = 750
     aes_color = aes.color === nothing ? [nothing] : aes.color
+    
+    groups = Dict(c => (eltype(aes.x)[], eltype(aes.y)[]) for c in unique(aes_color))
+    for (x, y, c) in zip(aes.x, aes.y, cycle(aes_color))
+        push!(groups[c][1], x)
+        push!(groups[c][2], y)
+    end
 
-        groups = Dict(c => (eltype(aes.x)[], eltype(aes.y)[]) for c in unique(aes_color))
-        for (x, y, c) in zip(aes.x, aes.y, cycle(aes_color))
-                push!(groups[c][1], x)
-                push!(groups[c][2], y)
+    local xs, ys, xsp
+    aes.x = eltype(aes.x)[]
+    # For aes.y returning a Float is ok if `y` is an Int or a Float 
+    # There does not seem to be strong demand for other types of `y`
+    aes.y = Float64[]
+    colors = eltype(aes_color)[]
+
+    for (c, (xv, yv)) in groups
+        x_min, x_max = minimum(xv), maximum(xv)
+        x_min == x_max && error("Stat.smooth requires more than one distinct x value")
+        try
+            xs = Float64.( eltype(xv) <: Dates.TimeType ? Dates.value.(xv) : xv )
+            ys = Float64.( eltype(yv) <: Dates.TimeType ? Dates.value.(yv) : yv )
+        catch e
+            error("Stat.loess and Stat.lm require that x and y be bound to arrays of plain numbers.")
+        end
+            
+        nudge = 1e-5 * (x_max - x_min)
+        
+        dx = (x_max-x_min)*(1/max_num_steps)
+        # For a Date, dx might be 0 days, so correct
+        # For Ints, correct dx
+        if isa(xv[1], Date)
+            dx = max(dx, Dates.Day(1))
+        elseif isa(xv[1], Int)
+            dx = ceil(Int, dx)
+            nudge = 0
         end
 
-        local xs, ys, xsp
-        aes.x = eltype(aes.x)[]
-        # For aes.y returning a Float is ok if `y` is an Int or a Float
-        # There does not seem to be strong demand for other types of `y`
-        aes.y = Float64[]
-        colors = eltype(aes_color)[]
-
-
-        for (c, (xv, yv)) in groups
-            x_min, x_max = minimum(xv), maximum(xv)
-            if x_min == x_max
-                error("Stat.smooth requires more than one distinct x value")
-            end
-            try
-                xs = Float64.( eltype(xv) <: Dates.TimeType ? Dates.value.(xv) : xv )
-                ys = Float64.( eltype(yv) <: Dates.TimeType ? Dates.value.(yv) : yv )
-            catch e
-                error("Stat.loess and Stat.lm require that x and y be bound to arrays of plain numbers.")
-            end
-
-            nudge = 1e-5 * (x_max - x_min)
-
-            dx = (x_max-x_min)*(1/max_num_steps)
-            # For a Date, dx might be 0 days, so correct
-            # For Ints, correct dx
-            if isa(xv[1], Date)
-                dx = max(dx, Dates.Day(1))
-            elseif isa(xv[1], Int)
-                dx = ceil(Int, dx)
-                nudge = 0
-            end
-
-            steps = collect((x_min + nudge):dx:(x_max - nudge))
-            xsp = Float64.( eltype(steps) <: Dates.TimeType ? Dates.value.(steps) : steps )
-            if stat.method == :loess
-                smoothys = Loess.predict(loess(xs, ys, span=stat.smoothing), xsp)
-            elseif stat.method == :lm
-                lmcoeff = linreg(xs,ys)
-                smoothys = lmcoeff[2].*xsp .+ lmcoeff[1]
-            end
-
-        # New aes
-            append!(aes.x, steps)
-            append!(aes.y, smoothys)
-            append!(colors, fill(c, length(steps)))
+        steps = collect((x_min + nudge):dx:(x_max - nudge))
+        xsp = Float64.( eltype(steps) <: Dates.TimeType ? Dates.value.(steps) : steps )
+        if stat.method == :loess
+            smoothys = Loess.predict(loess(xs, ys, span=stat.smoothing), xsp)
+        elseif stat.method == :lm
+            lmcoeff = linreg(xs,ys)
+            smoothys = lmcoeff[2].*xsp .+ lmcoeff[1]
         end
+    
+    # New aes 
+        append!(aes.x, steps)
+        append!(aes.y, smoothys)
+        append!(colors, fill(c, length(steps)))
+    end
 
-
-        if !(aes.color===nothing)
-            aes.color = PooledDataArray(colors)
-        end
- end
+    if !(aes.color===nothing)
+        aes.color = PooledDataArray(colors)
+    end
+end
 
 
 immutable HexBinStatistic <: Gadfly.StatisticElement
@@ -1210,9 +1167,8 @@ function apply_statistic(stat::HexBinStatistic,
     aes.ysize = [ysize]
 
     color_scale = scales[:color]
-    if !(typeof(color_scale) <: Scale.ContinuousColorScale)
-        error("HexBinGeometry requires a continuous color scale.")
-    end
+    typeof(color_scale) <: Scale.ContinuousColorScale ||
+            error("HexBinGeometry requires a continuous color scale.")
 
     aes.color_key_title = "Count"
 
@@ -1276,9 +1232,7 @@ function apply_statistic(stat::StepStatistic,
         u = i_offset + div(i - 1, 2) + (isodd(i) || stat.direction != :hv ? 0 : 1)
         v = i_offset + div(i - 1, 2) + (isodd(i) || stat.direction != :vh ? 0 : 1)
 
-        if u > length(aes.x) || v > length(aes.y)
-            break
-        end
+        (u > length(aes.x) || v > length(aes.y)) && break
 
         if (aes.color != nothing &&
              (aes.color[u] != aes.color[i_offset] || aes.color[v] != aes.color[i_offset])) ||
@@ -1376,11 +1330,9 @@ output_aesthetics(::ContourStatistic) = [:x, :y, :color, :group]
 
 const contour = ContourStatistic
 
-function default_scales(::ContourStatistic, t::Gadfly.Theme=Gadfly.current_theme())
-    return [Gadfly.Scale.z_func(), Gadfly.Scale.x_continuous(),
-            Gadfly.Scale.y_continuous(),
+default_scales(::ContourStatistic, t::Gadfly.Theme=Gadfly.current_theme()) =
+        [Gadfly.Scale.z_func(), Gadfly.Scale.x_continuous(), Gadfly.Scale.y_continuous(),
             t.continuous_color_scale]
-end
 
 function apply_statistic(stat::ContourStatistic,
                          scales::Dict{Symbol, Gadfly.ScaleElement},
@@ -1409,9 +1361,8 @@ function apply_statistic(stat::ContourStatistic,
         if ys == nothing
             ys = collect(Float64, 1:size(zs)[2])
         end
-        if size(zs) != (length(xs), length(ys))
-            error("Stat.contour requires dimension of z to be length(x) by length(y)")
-        end
+        size(zs) != (length(xs), length(ys)) &&
+                error("Stat.contour requires dimension of z to be length(x) by length(y)")
     else
         error("Stat.contour requires either a matrix or a function")
     end
@@ -1445,8 +1396,7 @@ function apply_statistic(stat::ContourStatistic,
 end
 
 
-immutable QQStatistic <: Gadfly.StatisticElement
-end
+immutable QQStatistic <: Gadfly.StatisticElement end
 
 input_aesthetics(::QQStatistic) = [:x, :y]
 output_aesthetics(::QQStatistic) = [:x, :y]
@@ -1511,7 +1461,6 @@ function apply_statistic(stat::QQStatistic,
         data.y = aes.y
         Scale.apply_scale(scales[:y], [aes], data)
     end
-
 end
 
 
@@ -1530,9 +1479,7 @@ function apply_statistic(stat::ViolinStatistic,
                          coord::Gadfly.CoordinateElement,
                          aes::Gadfly.Aesthetics)
 
-    if !isa(aes.y[1], Real)
-        error("Kernel density estimation only works on Real types.")
-    end
+    isa(aes.y[1], Real) || error("Kernel density estimation only works on Real types.")
 
     if aes.x === nothing
         y_f64 = collect(Float64, aes.y)
@@ -1585,9 +1532,7 @@ function minimum_span(vars::Vector{Symbol}, aes::Gadfly.Aesthetics)
     span = nothing
     for var in vars
         data = getfield(aes, var)
-        if length(data) < 2
-            continue
-        end
+        length(data) < 2 && continue
         dataspan = data[2] - data[1]
         T = eltype(data)
         z = convert(T, zero(T))
@@ -1612,9 +1557,7 @@ function apply_statistic(stat::JitterStatistic,
                          coord::Gadfly.CoordinateElement,
                          aes::Gadfly.Aesthetics)
     span = minimum_span(stat.vars, aes)
-    if span == nothing
-        return
-    end
+    span == nothing && return
 
     rng = MersenneTwister(stat.seed)
     for var in stat.vars
@@ -1626,10 +1569,7 @@ function apply_statistic(stat::JitterStatistic,
 end
 
 
-
 # Bin mean returns the mean of x and y in n bins of x
-
-
 immutable BinMeanStatistic <: Gadfly.StatisticElement
     n::Int
 end
@@ -1732,8 +1672,6 @@ function apply_statistic(stat::EnumerateStatistic,
 end
 
 
-
-
 immutable VecFieldStatistic <: Gadfly.StatisticElement
     smoothness::Float64
     scale::Float64
@@ -1745,9 +1683,8 @@ VecFieldStatistic(; smoothness=1.0, scale=1.0, samples=20) =
 input_aesthetics(stat::VecFieldStatistic) = [:z, :x, :y, :color]
 output_aesthetics(stat::VecFieldStatistic) = [:x, :y, :xend, :yend, :color]
 default_scales(stat::VecFieldStatistic, t::Gadfly.Theme=Gadfly.current_theme()) =
-    [Gadfly.Scale.z_func(), Gadfly.Scale.x_continuous(), Gadfly.Scale.y_continuous(),
-        t.continuous_color_scale ]
-
+        [Gadfly.Scale.z_func(), Gadfly.Scale.x_continuous(), Gadfly.Scale.y_continuous(),
+            t.continuous_color_scale ]
 
 const vectorfield = VecFieldStatistic
 
@@ -1800,8 +1737,5 @@ function apply_statistic(stat::VecFieldStatistic,
     Scale.apply_scale(color_scale, [aes], Gadfly.Data(color=Z))
 
 end
-
-
-
 
 end # module Stat

--- a/test/testscripts/negative_stacked_bar.jl
+++ b/test/testscripts/negative_stacked_bar.jl
@@ -1,0 +1,12 @@
+using Gadfly
+
+set_default_plot_size(12inch, 6inch)
+
+independent = [1,2,3,1,2,3]
+dependent = [4,5,6,1,2,3]
+group = [1,1,1,2,2,2]
+vpos = plot(x=independent, y=  dependent, color=group, Geom.bar(position=:stack, orientation=:vertical));
+hpos = plot(x=  dependent, y=independent, color=group, Geom.bar(position=:stack, orientation=:horizontal));
+vneg = plot(x=independent, y= -dependent, color=group, Geom.bar(position=:stack, orientation=:vertical));
+hneg = plot(x= -dependent, y=independent, color=group, Geom.bar(position=:stack, orientation=:horizontal));
+gridstack([vpos hpos; vneg hneg])


### PR DESCRIPTION
1. zoom in properly for stacked bars.  that is, set view{min,max} correctly

2. plot negative grouped and stacked bars properly.  some used to go positive.

3. fixed a depwarn, and

4. made some cosmetic changes for brevity along the way