### PR TITLE
better support in {h,v,grid}stack for using context() as empty placeholder

### DIFF
--- a/docs/src/man/layers.md
+++ b/docs/src/man/layers.md
@@ -54,7 +54,7 @@ Plots can also be stacked horizontally with `hstack` or vertically with `vstack`
 and arranged into a rectangular array with `gridstack`.
 This allows more customization in regards to tick marks, axis labeling, and other
 plot details than is available with [Geom.subplot_grid](@ref).  Use `title` to add
-a descriptive string at the top.
+a descriptive string at the top, and `context()` to leave a panel empty.
 
 ```julia
 p1 = plot(x=[1,2,3], y=[4,5,6])
@@ -68,5 +68,8 @@ p4 = plot(x=[5,7,8], y=[10,11,12])
 vstack(hstack(p1,p2),hstack(p3,p4))
 gridstack([p1 p2; p3 p4])
 
-title("My great data", hstack(p3,p4))
+title(hstack(p3,p4), "My great data")
+
+# empty panel
+gridstack(Union{Plot,Compose.Context}[p1 p2; p3 Compose.context()])
 ```

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -880,39 +880,58 @@ title(ctx::Context, str::String, props::Compose.Property...) = vstack(
 
 # Convenience stacking functions
 """
+    vstack(ps::Union{Plot,Context}...)
+    vstack(ps::Vector)
+
+Arrange plots into a vertical column.  Use `context()` as a placeholder for an empty panel.  Heterogeneous vectors must be typed.  See also `hstack`, `gridstack`, `subplot_grid`.
+
+# Examples
+
 ```
-vstack(ps::Plot...) = vstack(Context[render(p) for p in ps]...)
-vstack(ps::Vector{Plot}) = vstack(Context[render(p) for p in ps]...)
-vstack(p::Plot, c::Context) = vstack(render(p), c)
-vstack(c::Context, p::Plot) = vstack(c, render(p))
-```
-Plots can be stacked vertically to allow more customization in regards to tick marks, axis labeling, and other plot details than what is available with subplot_grid
+p1 = plot(x=[1,2], y=[3,4], Geom.line);
+p2 = Compose.context();
+vstack(p1, p2)
+vstack(Union{Plot,Compose.Context}[p1, p2])
 """
-vstack(ps::Plot...) = vstack(Context[render(p) for p in ps]...)
-vstack(ps::Vector{Plot}) = vstack(Context[render(p) for p in ps]...)
-vstack(p::Plot, c::Context) = vstack(render(p), c)
-vstack(c::Context, p::Plot) = vstack(c, render(p))
+vstack(ps::Union{Plot,Context}...) = vstack([typeof(p)==Plot ? render(p) : p for p in ps]...)
+vstack(ps::Vector{Plot}) = vstack(ps...)
+vstack(ps::Vector{Union{Plot,Context}}) = vstack(ps...)
 
 """
+    hstack(ps::Union{Plot,Context}...)
+    hstack(ps::Vector)
+
+Arrange plots into a horizontal row.  Use `context()` as a placeholder for an empty panel.  Heterogeneous vectors must be typed.  See also `vstack`, `gridstack`, `subplot_grid`.
+
+# Examples
+
 ```
-hstack(ps::Plot...) = hstack(Context[render(p) for p in ps]...)
-hstack(ps::Vector{Plot}) = hstack(Context[render(p) for p in ps]...)
-hstack(p::Plot, c::Context) = hstack(render(p), c)
-hstack(c::Context, p::Plot) = hstack(c, render(p))
-```
-Plots can be stacked horizontally to allow more customization in regards to tick marks, axis labeling, and other plot details than what is available with subplot_grid
+p1 = plot(x=[1,2], y=[3,4], Geom.line);
+p2 = Compose.context();
+hstack(p1, p2)
+hstack(Union{Plot,Compose.Context}[p1, p2])
 """
-hstack(ps::Plot...) = hstack(Context[render(p) for p in ps]...)
-hstack(ps::Vector{Plot}) = hstack(Context[render(p) for p in ps]...)
-hstack(p::Plot, c::Context) = hstack(render(p), c)
-hstack(c::Context, p::Plot) = hstack(c, render(p))
+hstack(ps::Union{Plot,Context}...) = hstack([typeof(p)==Plot ? render(p) : p for p in ps]...)
+hstack(ps::Vector{Plot}) = hstack(ps...)
+hstack(ps::Vector{Union{Plot,Context}}) = hstack(ps...)
 
 """
-    gridstack(ps::Matrix{Plot}) -> Context
+    gridstack(ps::Matrix{Union{Plot,Context}})
 
-Arrange plots into a rectangular array.
+Arrange plots into a rectangular array.  Use `context()` as a placeholder for an empty panel.  Heterogeneous matrices must be typed.  See also `hstack`, `vstack`.
+
+# Examples
+
+```
+p1 = plot(x=[1,2], y=[3,4], Geom.line);
+p2 = Compose.context();
+gridstack([p1 p1; p1 p1])
+gridstack(Union{Plot,Compose.Context}[p1 p2; p2 p1])
+```
 """
-gridstack(ps::Matrix{Plot}) = gridstack(map(render, ps))
+_gridstack(ps::Matrix) = gridstack(map(p->typeof(p)==Plot ? render(p) : p, ps))
+gridstack(ps::Matrix{Plot}) = _gridstack(ps)
+gridstack(ps::Matrix{Union{Plot,Context}}) = _gridstack(ps)
 
 # show functions for all supported compose backends.
 

--- a/test/testscripts/gridstack_empty_args.jl
+++ b/test/testscripts/gridstack_empty_args.jl
@@ -1,0 +1,7 @@
+using Gadfly, Compose
+
+set_default_plot_size(8inch,6inch)
+
+p=plot(y=[1,2,3], Geom.line)
+c=Compose.context()
+gridstack(Union{Plot,Compose.Context}[p c; c p])

--- a/test/testscripts/hstack_empty_args.jl
+++ b/test/testscripts/hstack_empty_args.jl
@@ -1,0 +1,7 @@
+using Gadfly, Compose
+
+set_default_plot_size(12inch,3inch)
+
+p=plot(y=[1,2,3], Geom.line)
+c=Compose.context()
+hstack(p,c,p,c,p)

--- a/test/testscripts/hstack_empty_vector.jl
+++ b/test/testscripts/hstack_empty_vector.jl
@@ -1,0 +1,7 @@
+using Gadfly, Compose
+
+set_default_plot_size(12inch,3inch)
+
+p=plot(y=[1,2,3], Geom.line)
+c=Compose.context()
+hstack(Union{Plot,Compose.Context}[p,c,p,c,p])

--- a/test/testscripts/vstack_empty_args.jl
+++ b/test/testscripts/vstack_empty_args.jl
@@ -1,0 +1,7 @@
+using Gadfly, Compose
+
+set_default_plot_size(4inch,9inch)
+
+p=plot(y=[1,2,3], Geom.line)
+c=Compose.context()
+vstack(p,c,p,c,p)

--- a/test/testscripts/vstack_empty_vector.jl
+++ b/test/testscripts/vstack_empty_vector.jl
@@ -1,0 +1,7 @@
+using Gadfly, Compose
+
+set_default_plot_size(4inch,9inch)
+
+p=plot(y=[1,2,3], Geom.line)
+c=Compose.context()
+vstack(Union{Plot,Compose.Context}[p,c,p,c,p])


### PR DESCRIPTION
```vstack(plot, context, plot, context, ...)``` now works.  before the args had to either all be plots, or there could just be a pair with one of them being a context.