### PR TITLE
more test refinements

### DIFF
--- a/test/compare_examples.jl
+++ b/test/compare_examples.jl
@@ -5,7 +5,8 @@ cachedout = joinpath((@compat @__DIR__), "cachedoutput")
 gennedout = joinpath((@compat @__DIR__), "gennedoutput")
 ndifferentfiles = 0
 const creator_producer = r"(Creator|Producer)"
-for file in readdir(cachedout)
+for file in filter(x->x[1]!='.', readdir(cachedout))
+    print("Comparing ", file, " ... ")
     cached = open(readlines, joinpath(cachedout, file))
     genned = open(readlines, joinpath(gennedout, file))
     same = (n=length(cached)) == length(genned)
@@ -22,10 +23,13 @@ for file in readdir(cachedout)
         end
         same = same & all(lsame)
     end
-    if !same
+    if same
+        println("same!")
+    else
         ndifferentfiles +=1
-        println(string(file, " differs:\n", readstring(ignorestatus(
-                `diff $(joinpath(cachedout, file)) $(joinpath(gennedout, file))`))))
+        println("different :(")
+        println(readstring(ignorestatus(
+                `diff $(joinpath(cachedout, file)) $(joinpath(gennedout, file))`)))
         run(`open $(joinpath(cachedout,file))`)
         run(`open $(joinpath(gennedout,file))`)
         println("Press the return/enter key to continue")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,10 +23,11 @@ backends = @compat Dict{AbstractString, Function}(
 )
 
 testdir = joinpath((@compat @__DIR__),"testscripts")
-testfiles = isempty(ARGS) ? [splitext(filename)[1] for filename in readdir(testdir)] : ARGS
+testfiles = isempty(ARGS) ?
+        [splitext(filename)[1] for filename in readdir(testdir) if filename[1]!='.'] :
+        ARGS
 
 for filename in testfiles, (backend_name, backend) in backends
-    startswith(filename,'.') && continue
     println(STDERR, "Rendering $(filename) on $(backend_name) backend.")
     try
         srand(1)
@@ -77,5 +78,5 @@ end
 if !haskey(ENV, "TRAVIS") &&
             !isempty(readdir(joinpath((@compat @__DIR__),"cachedoutput"))) &&
             !isempty(readdir(joinpath((@compat @__DIR__),"gennedoutput")))
-    include("compare_examples.jl")
+    run(`julia compare_examples.jl`)  # `include`ing causes it to hang.  bug in julia 0.6?
 end

--- a/test/testscripts/subplot_grid.jl
+++ b/test/testscripts/subplot_grid.jl
@@ -9,6 +9,7 @@ else
     set_levels!(barley[:Year], ["1931", "1932"])
 end
 
-plot(barley,
+idx = [startswith(x,"No.") for x in barley[:Variety]]
+plot(barley[idx,:],
      xgroup="Variety", ygroup="Site", x="Year", y="Yield",
      Geom.subplot_grid(Geom.line, Geom.point))

--- a/test/testscripts/subplot_grid_free_axis.jl
+++ b/test/testscripts/subplot_grid_free_axis.jl
@@ -9,7 +9,8 @@ else
     set_levels!(barley[:Year], ["1931", "1932"])
 end
 
-plot(barley,
+idx = [startswith(x,"No.") for x in barley[:Variety]]
+plot(barley[idx,:],
      xgroup="Variety", ygroup="Site", x="Year", y="Yield",
      Geom.subplot_grid(Geom.line, Geom.point,
                        free_x_axis=true, free_y_axis=true))

--- a/test/testscripts/subplot_grid_free_y_1.jl
+++ b/test/testscripts/subplot_grid_free_y_1.jl
@@ -1,8 +1,10 @@
-using Gadfly, RDatasets
+using Gadfly, RDatasets, Compat
 
-set_default_plot_size(30cm, 10cm)
+set_default_plot_size(15cm, 15cm)
 
-plot(dataset("mlmRev", "Chem97"),
+d = dataset("mlmRev", "Chem97")
+idx = find((d[:Score] .> 4) .& (d[:Age] .> 0))
+plot(d[idx[1:4:end], :],
      x=:GCSEScore,
      ygroup=:Gender,
      xgroup=:Score,

--- a/test/testscripts/subplot_grid_free_y_2.jl
+++ b/test/testscripts/subplot_grid_free_y_2.jl
@@ -1,9 +1,11 @@
 using Gadfly, RDatasets
 
-set_default_plot_size(10cm, 30cm)
+set_default_plot_size(10cm, 15cm)
 
-plot(dataset("mlmRev", "Chem97"),
+d=dataset("mlmRev", "Chem97")
+idx = d[:Age] .>0
+plot(d[idx,:],
      x=:GCSEScore,
      ygroup=:Age,
      color=:Gender,
-     Geom.subplot_grid(Geom.histogram, free_y_axis=true))
+     Geom.subplot_grid(Geom.histogram(bincount=20), free_y_axis=true))


### PR DESCRIPTION
`subplot_grid_free_y_1` output a 7MB svg, which took so long to render it frequently hung travis.  this PR simplifies this test, along with a few other subplot tests which also output large files.  and it also fixes a bug in the automated regression testing.