### PR TITLE
enable Scale.size_identity with Geom.point

### DIFF
--- a/src/geom/point.jl
+++ b/src/geom/point.jl
@@ -29,10 +29,12 @@ function render(geom::PointGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
     default_aes.size = Measure[theme.point_size]
     aes = inherit(aes, default_aes)
 
-    size_min, size_max = extrema(aes.size)
-    size_range = size_max - size_min
-    point_size_range = theme.point_size_max - theme.point_size_min
-    interpolate_size(x) = theme.point_size_min + (x-size_min) / size_range * point_size_range
+    if eltype(aes.size) <: Int
+      size_min, size_max = extrema(aes.size)
+      size_range = size_max - size_min
+      point_size_range = theme.point_size_max - theme.point_size_min
+      interpolate_size(x) = theme.point_size_min + (x-size_min) / size_range * point_size_range
+    end
 
     ctx = context()
 


### PR DESCRIPTION
a small change which might generally be useful.  my specific use case is to be able to use text as marker points.  what follows is a bit of a hack of `Geom.point`.  in future, we might want to add a `Geom.text` so that for example, the font family, size, weight, etc. could be varied from point to point.

```
function textshape(xs::AbstractArray, ys::AbstractArray, vs::AbstractArray)
    n = max(length(xs), length(ys), length(vs))

    text_xs = Vector{Measures.Measure}(n)
    text_ys = Vector{Measures.Measure}(n)
    text_vs = Vector{AbstractString}(n)
    for i in 1:n
        text_xs[i] = Gadfly.x_measure(xs[1 + i % length(xs)])
        text_ys[i] = Gadfly.y_measure(ys[1 + i % length(ys)])
        text_vs[i] = vs[1 + i % length(vs)]
    end

    return Compose.text(text_xs, text_ys, text_vs, fill(Compose.hcenter,n), fill(Compose.vcenter,n))
end

plot(y=[1,2,3], size=["41","42","43"], Geom.point,
    shape=[textshape], Scale.size_identity,
    Theme(default_color="black",highlight_width=0mm))
```