### PR TITLE
fix Geom.bar when only some data is negative

### DIFF
--- a/docs/src/lib/geoms/geom_bar.md
+++ b/docs/src/lib/geoms/geom_bar.md
@@ -39,9 +39,21 @@ If `x` is given, a bar will be drawn at each x value, specifying both `xmin` and
 ```@setup 1
 using RDatasets
 using Gadfly
-Gadfly.set_default_plot_size(12cm, 8cm)
+set_default_plot_size(12cm, 8cm)
 ```
 
 ```@example 1
 plot(dataset("HistData", "ChestSizes"), x="Chest", y="Count", Geom.bar)
+```
+
+```@setup 2
+using RDatasets
+using Gadfly
+set_default_plot_size(12cm, 8cm)
+```
+
+```@example 1
+plot(by(dataset("datasets","HairEyeColor"),[:Eye,:Sex], d->sum(d[:Freq])),
+    color="Eye", y="x1", x="Sex",
+    Geom.bar(position=:dodge), Guide.ylabel("Freq"))
 ```

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -201,17 +201,14 @@ function apply_statistic(stat::BarStatistic,
             end
         end
 
-        stack_height = values(groups)
-        if any(x->x>0.0, stack_height)
-          viewextrema = @compat Float64(maximum(stack_height))
-          viewextremavar = viewmaxvar
-        else
-          viewextrema = @compat Float64(minimum(stack_height))
-          viewextremavar = viewminvar
+        viewmin, viewmax = extrema(values(groups))
+        aes_viewminvar = getfield(aes, viewminvar)
+        if aes_viewminvar === nothing || aes_viewminvar > viewmin
+            setfield!(aes, viewminvar, viewmin)
         end
-        aes_viewextrema = getfield(aes, viewextremavar)
-        if aes_viewextrema === nothing || aes_viewextrema < viewextrema
-            setfield!(aes, viewextremavar, viewextrema)
+        aes_viewmaxvar = getfield(aes, viewmaxvar)
+        if aes_viewmaxvar === nothing || aes_viewmaxvar < viewmax
+            setfield!(aes, viewmaxvar, viewmax)
         end
     end
 

--- a/test/testscripts/negative_positive_stacked_bar.jl
+++ b/test/testscripts/negative_positive_stacked_bar.jl
@@ -1,0 +1,7 @@
+using Gadfly
+
+set_default_plot_size(8inch, 3inch)
+
+hstack(
+    plot(x=[1,2,3,1],y=[-1,2,3,-4],color=["a","a","a","b"],Geom.bar),
+    plot(y=[1,2,3,1],x=[-1,2,3,-4],color=["a","a","a","b"],Geom.bar(orientation=:horizontal)) )


### PR DESCRIPTION
closes https://github.com/GiovineItalia/Gadfly.jl/issues/928

note that i'm not sure it's a good idea to have `position` default to `stack`.  there are actually three codepaths in Geom.bar:  stacked, dodged, and then a third unnamed one for data in which there is only one bar at any given "x" value.  more often than not i would think the latter would apply.  don't want to break anything though so have left it alone for now.