### PR TITLE
make hexbins equilateral

### DIFF
--- a/src/geom/hexbin.jl
+++ b/src/geom/hexbin.jl
@@ -36,8 +36,6 @@ function render(geom::HexagonalBinGeometry, theme::Gadfly.Theme, aes::Gadfly.Aes
     return compose!(
         context(),
         Compose.polygon([hexpoints(xs[i], ys[i], xsizes[i], ysizes[i]) for i in 1:n], geom.tag),
-        linewidth(0.1mm), # pad the hexagons so they ovelap a little
         fill(cs),
-        stroke(cs),
         svgclass("geometry"))
 end


### PR DESCRIPTION
because SVG strokes are half inside and half outside the shape that they bound, the hexagons in Geom.hexbin weren't equilateral.  removing the stroke and retaining the fill fixes this.  there is some whitespace between the hexagons with this PR, but at least on my 216 dpi display, it looks fine, and is much better than having non-uniform hexagons.

before:
![image](https://user-images.githubusercontent.com/1538268/30328435-5601d956-979d-11e7-8c11-d7ad1e5dc2c3.png)

after:
![image](https://user-images.githubusercontent.com/1538268/30328473-73e7d3da-979d-11e7-94f1-84b5a0a217c0.png)



