### PR TITLE
fix Scale.color_discrete default input args

### DIFF
--- a/src/scale.jl
+++ b/src/scale.jl
@@ -459,7 +459,7 @@ function color_discrete_hue(f=default_discrete_colors;
                             order=nothing,
                             preserve_order=true)
     DiscreteColorScale(
-        default_discrete_colors,
+        f,
         levels=levels,
         order=order,
         preserve_order=preserve_order)

--- a/test/testscripts/discrete_color_hue.jl
+++ b/test/testscripts/discrete_color_hue.jl
@@ -1,0 +1,4 @@
+using Gadfly, Colors
+
+plot(ones(10,3).*[1 2 3], x=Row.index, y=Col.value, color=Col.index,
+        Geom.line, Scale.color_discrete_hue(x->linspace(RGB(1,0,0),RGB(0,0,1),x)))


### PR DESCRIPTION
previously, `color_discrete` always used the default color generating function, even if one was passed in by the user.