### PR TITLE
fix Geom.bar with color and only a single x category

### DIFF
--- a/src/geom/bar.jl
+++ b/src/geom/bar.jl
@@ -255,7 +255,7 @@ function render(geom::BarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
         error("Orientation must be :horizontal or :vertical")
     end
 
-    if aes.color === nothing || allunique(aes.color)
+    if aes.color === nothing
         ctx = render_bar(geom, theme, aes, geom.orientation)
     elseif geom.position == :stack
         if geom.orientation == :horizontal

--- a/test/testscripts/color_bar.jl
+++ b/test/testscripts/color_bar.jl
@@ -1,0 +1,14 @@
+using Gadfly
+
+set_default_plot_size(8inch, 3inch)
+
+dodge1 = plot(x=["a","a"], y=[3,2], color=["red","blue"],
+      Geom.bar(position=:dodge));
+dodge2 = plot(x=["a","a","b","b"], y=[3,2,1,2], color=["red","blue","red","blue"],
+      Geom.bar(position=:dodge));
+stack1 = plot(x=["a","a"], y=[3,2], color=["red","blue"],
+      Geom.bar(position=:stack));
+stack2 = plot(x=["a","a","b","b"], y=[3,2,1,2], color=["red","blue","red","blue"],
+      Geom.bar(position=:stack));
+
+gridstack([dodge1 dodge2; stack1 stack2])


### PR DESCRIPTION
previously this code:

```
dodge1 = plot(x=["a","a"], y=[3,2], color=["red","blue"],
                    Geom.bar(position=:dodge));
stack1 = plot(x=["a","a"], y=[3,2], color=["red","blue"],
                    Geom.bar(position=:stack));
hstack(dodge1,stack1)
```

produced this plot:

<img width="380" alt="untitled" src="https://user-images.githubusercontent.com/1538268/32386531-f68b9e20-c097-11e7-94af-65f2a6a17f39.png">

note how the two colors are plotted on top of each other.

this PR fixes it such they are now stacked or dodged as specified:

<img width="382" alt="untitled2" src="https://user-images.githubusercontent.com/1538268/32386626-3af2bf94-c098-11e7-985a-b2edec879923.png">
