### PR TITLE
gather circle, square, etc into new Shape module

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,6 +22,7 @@ makedocs(
             hide("Statistics" => "lib/stats.md", load_dir("stats")),
             hide("Coords" => "lib/coords.md", load_dir("coords")),
             hide("Scales" => "lib/scales.md", load_dir("scales")),
+            "Shapes" => "lib/shapes.md",
         ],
         "Development" => Any[
             "Rendering Pipeline" => "dev/pipeline.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,18 +39,6 @@ julia> using Gadfly
 Now that you have it loaded, check out the [Tutorial](@ref) for a tour of
 basic plotting and the various manual pages for more advanced usages.
 
-## Manual outline
-
-```@contents
-Pages = [
-    "man/plotting.md",
-    "man/layers.md",
-    "man/backends.md",
-    "man/themes.md"
-]
-Depth = 1
-```
-
 ## Credits
 
 Gadfly is predominantly the work of Daniel C. Jones who initiated the

--- a/docs/src/lib/shapes.md
+++ b/docs/src/lib/shapes.md
@@ -1,0 +1,23 @@
+```@meta
+Author = "Ben J. Arthur"
+```
+
+# Shapes
+
+Shapes, when combined with [Geom.point](@ref), specify the appearance of
+markers.  Available shapes include circle, square, diamond, cross, xcross,
+utriangle, dtriangle, star1, star2, hexagon, octogon, hline, and vline.
+
+# Examples
+
+```@setup 1
+using RDatasets
+using Gadfly
+set_default_plot_size(12cm, 8cm)
+```
+
+```@example 1
+plot(dataset("HistData","DrinksWages"),
+    x="Wage", y="Drinks", shape=[Shape.square],
+    Geom.point, Scale.y_log10)
+```

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -19,10 +19,22 @@ import Base: +, -, /, *,
              show, isfinite, display
 import Distributions: Distribution
 
-export Plot, Layer, Theme, Col, Row, Scale, Coord, Geom, Guide, Stat, render, plot,
+export Plot, Layer, Theme, Col, Row, Scale, Coord, Geom, Guide, Stat, Shape, render, plot,
        style, layer, spy, set_default_plot_size, set_default_plot_format, prepare_display
-export circle, square, diamond, cross, xcross, utriangle, dtriangle, star1, star2,
-       hexagon, octogon, hline, vline
+
+@deprecate circle Shape.circle
+@deprecate square Shape.square
+@deprecate diamond Shape.diamond
+@deprecate cross Shape.cross
+@deprecate xcross Shape.xcross
+@deprecate utriangle Shape.utriangle
+@deprecate dtriangle Shape.dtriangle
+@deprecate star1 Shape.star1
+@deprecate star2 Shape.star2
+@deprecate hexagon Shape.hexagon
+@deprecate octogon Shape.octogon
+@deprecate hline Shape.hline
+@deprecate vline Shape.vline
 
 # Re-export some essentials from Compose
 export SVGJS, SVG, PGF, PNG, PS, PDF, draw, inch, mm, cm, px, pt, color, @colorant_str, vstack, hstack, title, gridstack

--- a/src/geom/beeswarm.jl
+++ b/src/geom/beeswarm.jl
@@ -129,9 +129,9 @@ function render(geom::BeeswarmGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthet
         end
 
         if geom.orientation == :horizontal
-            f = circle(val, positions, aes.size, geom.tag)
+            f = Shape.circle(val, positions, aes.size, geom.tag)
         else
-            f = circle(positions, val, aes.size, geom.tag)
+            f = Shape.circle(positions, val, aes.size, geom.tag)
         end
 
         return compose(context(), f, fill(aes.color),

--- a/src/geom/boxplot.jl
+++ b/src/geom/boxplot.jl
@@ -117,7 +117,7 @@ function render(geom::BoxplotGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
                              for (x, ys, c) in zip(xs, aes.outliers, cs)]...))
         compose!(ctx,
             (context(),
-             circle([x for (x, y, c) in xys],
+             Shape.circle([x for (x, y, c) in xys],
                     [y for (x, y, c) in xys],
                     [theme.point_size], to),
              stroke([theme.discrete_highlight_color(c) for (x, y, c) in xys]),

--- a/src/geom/point.jl
+++ b/src/geom/point.jl
@@ -24,7 +24,7 @@ function render(geom::PointGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
     Gadfly.assert_aesthetics_equal_length("Geom.point", aes, :x, :y)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.shape = Function[Gadfly.circle]
+    default_aes.shape = Function[Shape.circle]
     default_aes.color = PooledDataArray(RGBA{Float32}[theme.default_color])
     default_aes.size = Measure[theme.point_size]
     aes = inherit(aes, default_aes)

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -1,6 +1,9 @@
 # Compose pseudo-forms for simple symbols, all parameterized by center and size
 
-using Compose: x_measure, y_measure
+module Shape
+
+using Measures
+using Compose: x_measure, y_measure, circle, rectangle, polygon
 
 function square(xs::AbstractArray, ys::AbstractArray, rs::AbstractArray)
     n = max(length(xs), length(ys), length(rs))
@@ -216,3 +219,5 @@ function vline(xs::AbstractArray, ys::AbstractArray, rs::AbstractArray)
 
     return line(line_ps)
 end
+
+end  # module Shape

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -69,9 +69,9 @@ end
     point_size_max,        Measure,         1.8mm
 
     # Symbol forms used for the shape aesthetic
-    point_shapes,          Vector{Function},  [circle, square, diamond, cross, xcross,
-                                               utriangle, dtriangle, star1, star2,
-                                               hexagon, octagon, hline, vline]
+    point_shapes,          Vector{Function},  [Shape.circle, Shape.square, Shape.diamond, Shape.cross, Shape.xcross,
+                                               Shape.utriangle, Shape.dtriangle, Shape.star1, Shape.star2,
+                                               Shape.hexagon, Shape.octagon, Shape.hline, Shape.vline]
 
     # Width of lines in the line geometry.
     line_width,            Measure,         0.3mm

--- a/test/testscripts/point_color_shape_size.jl
+++ b/test/testscripts/point_color_shape_size.jl
@@ -4,6 +4,6 @@ set_default_plot_size(6inch, 6inch)
 
 plot(x=rand(100), y=rand(100),
      color=rand([colorant"red",colorant"blue",colorant"green"], 100),
-     shape=rand([circle,square,utriangle], 100),
+     shape=rand([Shape.circle,Shape.square,Shape.utriangle], 100),
      size=rand([1mm, 2mm, 3mm], 100),
      Geom.point)

--- a/test/testscripts/point_shape_explicit.jl
+++ b/test/testscripts/point_shape_explicit.jl
@@ -2,4 +2,6 @@ using Gadfly
 
 set_default_plot_size(6inch, 6inch)
 
-plot(x=rand(100), y=rand(100), shape=rand([circle,square,utriangle], 100), Geom.point)
+plot(x=rand(100), y=rand(100),
+    shape=rand([Shape.circle,Shape.square,Shape.utriangle], 100),
+    Geom.point)


### PR DESCRIPTION
fixes https://github.com/GiovineItalia/Gadfly.jl/issues/1019

does anyone know how to deprecate `circle`, `square`, etc.?  they used to be exported, but now one must say `Shape.circle`, `Shape.square`, etc.  i tried `@deprecate` in various places, but it seems to be meant only for a name / argument change, and not for changes in whether it's exported or not.

also, since this is a breaking change, i believe we should increment the minor release version on the next tag.

lastly, is anyone else having trouble building the docs locally?  i'm getting errors:

```
$ julia docs/make.jl
Documenter: setting up build directory.
Documenter: expanding markdown templates.
ERROR: LoadError: UndefVarError: distinguishable_colors not defined
Stacktrace:
 [1] gen_colors(::Int64) at ./none:3
 [2] apply_scale(::Gadfly.Scale.DiscreteColorScale, ::Array{Gadfly.Aesthetics,1}, ::Gadfly.Data, ::Vararg{Gadfly.Data,N} where N) at /Users/arthurb/.julia/v0.6/Gadfly/src/scale.jl:502
```