### PR TITLE
build docs on top 0.6 since 0.5 support was dropped

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,7 +32,7 @@ makedocs(
 
 deploydocs(
     repo   = "github.com/GiovineItalia/Gadfly.jl.git",
-    julia  = "0.5",
+    julia  = "0.6",
     osname = "linux",
     deps = nothing,
     make = nothing,


### PR DESCRIPTION
See https://github.com/JuliaDocs/Documenter.jl/pull/555