### PR TITLE
fix Shape.{h,v}line

### DIFF
--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -3,7 +3,7 @@
 module Shape
 
 using Measures
-using Compose: x_measure, y_measure, circle, rectangle, polygon
+using Compose: x_measure, y_measure, circle, rectangle, polygon, line
 
 function square(xs::AbstractArray, ys::AbstractArray, rs::AbstractArray)
     n = max(length(xs), length(ys), length(rs))

--- a/test/testscripts/shape_hvline.jl
+++ b/test/testscripts/shape_hvline.jl
@@ -1,0 +1,4 @@
+using Gadfly
+
+hstack(plot(y=[1,2,3],shape=[Shape.vline], Theme(discrete_highlight_color=x->x)),
+       plot(y=[1,2,3],shape=[Shape.hline], Theme(discrete_highlight_color=x->x)))


### PR DESCRIPTION
fixes an oversight when refactoring for the new Shape module, and adds a test to make sure it doesn't happen again.