### PR TITLE
Fix bug in BoxplotStatistic

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1022,7 +1022,7 @@ function apply_statistic(stat::BoxplotStatistic,
 
             if stat.method == :tukey
                 aes.lower_hinge[i], aes.middle[i], aes.upper_hinge[i] =
-                        quantile!(ys, [0.25, 0.5, 0.75])
+                        quantile(ys, [0.25, 0.5, 0.75])
                 iqr = aes.upper_hinge[i] - aes.lower_hinge[i]
 
                 idx = searchsortedfirst(ys, aes.lower_hinge[i] - 1.5iqr)


### PR DESCRIPTION
quantile!() may modify/permute the content of ys. This possibly leads to a wrong idx because searchsortedfirst(...) and searchsortedlast(...) use their own additional sorting routine.
As a reason lower and upper_fence can be wrong.