### PR TITLE
Geom.hair

### DIFF
--- a/docs/src/lib/geoms/geom_hair.md
+++ b/docs/src/lib/geoms/geom_hair.md
@@ -1,0 +1,37 @@
+```@meta
+Author = "Mattriks"
+```
+
+# Geom.hair
+
+Draws a line from the points to some `intercept` (base line). Looks like hairs standing on end, hence called a hair plot. Also known as a lollipop chart if the end points are plotted.
+
+## Aesthetics
+
+  * `x`: Position of points.
+  * `y`: Position of points.
+  * `color` (optional): Color.
+
+## Arguments
+
+  * `intercept`: Base of hairs. Defaults to zero. 
+  * `orientation`: `:vertical` (default) or `:horizontal`
+
+## Examples
+
+```@setup 1
+using Gadfly
+Gadfly.set_default_plot_size(15cm, 7.5cm)
+```
+
+```@example 1
+x= 1:10
+s = [-1,-1,1,1,-1,-1,1,1,-1,-1]
+pa = plot(x=x, y=x.^2, Geom.hair, Geom.point)
+pb = plot(x=s.*(x.^2), y=x, Geom.hair(orientation=:horizontal), Geom.point, color=string.(s), Theme(key_position=:none))
+hstack(pa, pb)
+```
+
+
+
+

--- a/src/geom/segment.jl
+++ b/src/geom/segment.jl
@@ -15,6 +15,9 @@ const segment = SegmentGeometry
 # Leave this as a function, pending extra arguments e.g. arrow attributes
 vector(; filled::Bool=false) = SegmentGeometry(arrow=true, filled=filled)
 
+hair(;intercept=0.0, orientation=:vertical) = 
+    SegmentGeometry(Gadfly.Stat.hair(intercept, orientation))
+
 function vectorfield(;smoothness=1.0, scale=1.0, samples=20, filled::Bool=false)
     return SegmentGeometry(
         Gadfly.Stat.vectorfield(smoothness, scale, samples), 

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1779,4 +1779,35 @@ function apply_statistic(stat::VecFieldStatistic,
 
 end
 
+
+immutable HairStatistic <: Gadfly.StatisticElement
+    intercept
+    orientation::Symbol # :horizontal or :vertical like BarStatistic
+end
+HairStatistic(;intercept=0.0, orientation=:vertical) = HairStatistic(intercept, orientation)
+
+input_aesthetics(stat::HairStatistic) = [:x, :y]
+
+output_aesthetics(stat::HairStatistic) = [:x, :y, :xend, :yend]
+
+default_scales(stat::HairStatistic) = [Gadfly.Scale.x_continuous(), Gadfly.Scale.y_continuous()]
+
+const hair = HairStatistic
+
+function apply_statistic(stat::HairStatistic,
+                         scales::Dict{Symbol, Gadfly.ScaleElement},
+                         coord::Gadfly.CoordinateElement,
+                         aes::Gadfly.Aesthetics)
+    if stat.orientation == :vertical
+        aes.xend = aes.x
+        aes.yend = fill(stat.intercept, length(aes.y))
+    else
+        aes.yend = aes.y
+        aes.xend = fill(stat.intercept, length(aes.x))
+    end
+end
+
+
+
+
 end # module Stat

--- a/test/testscripts/hair.jl
+++ b/test/testscripts/hair.jl
@@ -1,0 +1,14 @@
+
+
+using  Gadfly
+
+set_default_plot_size(6inch, 3inch)
+
+
+x= 1:10
+s = [-1,-1,1,1,-1,-1,1,1,-1,-1]
+pa = plot(x=x, y=x.^2, Geom.hair, Geom.point)
+pb = plot(x=s.*(x.^2), y=x, Geom.hair(orientation=:horizontal), Geom.point, color=string.(s), Theme(key_position=:none))
+hstack(pa, pb)
+
+


### PR DESCRIPTION
Adds a new geometry: `Geom.hair`, so-called because the lines look like hairs standing on end (requested in #1011). See the doc file. Some examples:
```
x= 1:10
s = [-1,-1,1,1,-1,-1,1,1,-1,-1]
pa = plot(x=x, y=x.^2, Geom.hair, Geom.point)
pb = plot(x=x, y=x.^2, Geom.hair(intercept=50), Geom.point)
pc = plot(x=s.*(x.^2), y=x, Geom.hair(orientation=:horizontal), Geom.point, color=string.(s), Theme(key_position=:none))
hstack(pa,pb,pc)
```

![issue1011](https://user-images.githubusercontent.com/18226881/34435690-a40732a4-ece3-11e7-98a0-08ae01ed1f76.png)

