### PR TITLE
Configure plot_padding

### DIFF
--- a/docs/src/man/themes.md
+++ b/docs/src/man/themes.md
@@ -39,7 +39,7 @@ These parameters can either be used with `Theme` or `style`
     Nothing)
   * `background_color`: Background color for the entire plot. If nothing, no
     background. (Color or Nothing)
-  * `plot_padding`: How much padding should be put around the plot as a whole (Measure)
+  * `plot_padding`: Padding around the plot. The order of padding is: `plot_padding=[left, right, top, bottom]`. If a vector of length one is provided e.g.  `[5mm]` then that value is applied to all sides. Absolute or relative units can be used. (Vector{<:Measure})
   * `grid_color`: Color of grid lines. (Color or Nothing)
   * `grid_color_focused`: In the D3 backend, mousing over the plot makes the
     grid lines emphasised by transitioning to this color. (Color or Nothing)

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -766,7 +766,7 @@ function render(plot::Plot)
                                    layer_subplot_datas,
                                    scales, guides)
 
-    ctx =  pad_inner(root_context, plot.theme.plot_padding)
+    ctx =  pad_inner(root_context, plot.theme.plot_padding...)
 
     if plot.theme.background_color != nothing
         compose!(ctx, (context(order=-1000000),

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -93,7 +93,7 @@ end
     background_color,      ColorOrNothing,  nothing
 
     # Padding around the entire plot
-    plot_padding,          Measure,         5mm
+    plot_padding,          (@compat Vector{<:Measure}),         [5mm]
 
     # Grid line color.
     grid_color,            ColorOrNothing,  colorant"#D0D0E0"

--- a/test/testscripts/Theme_plot_padding.jl
+++ b/test/testscripts/Theme_plot_padding.jl
@@ -1,0 +1,17 @@
+
+# issue 1018
+using Compose, DataFrames, Gadfly
+Gadfly.push_theme(Theme(default_color=colorant"black", background_color="white"))
+
+xscale = Scale.x_continuous(format=:plain)
+gp = Geom.polygon(preserve_order=true)
+D = DataFrame(x=[0, 0, 10^6, 10^6], y=[0, 10, 10, 0])
+
+# Padding
+# In absolute units:
+pa = plot(D, x=:x, y=:y, gp, xscale, style(plot_padding=[10mm,10mm,5mm,5mm]))
+# In relative units (relative to width & height of plot)
+pb = plot(D, x=:x, y=:y, gp, xscale, style(plot_padding=[0.05w,0.05w,0.2h,0.2h]))
+# 1mm padding on all sides, note x-axis right label gets cut deliberately
+pc = plot(D, x=:x, y=:y, gp, xscale, style(plot_padding=[1mm]))
+hstack(pa,pb,pc)


### PR DESCRIPTION
Here is my two line solution to the `plot_padding` issue (#1018). Plus I updated the `Theme` doc file. Should I add a test file?  Some examples:

```Julia
 using Compose, DataFrames, Gadfly
 Gadfly.push_theme(Theme(default_color=colorant"black", background_color="white"))

# Note the padding order is fixed by Compose.jl:
# plot_padding = [left, right, top, bottom]

xscale = Scale.x_continuous(format=:plain)
gp = Geom.polygon(preserve_order=true)
D = DataFrame(x=[0, 0, 10^6, 10^6], y=[0, 10, 10, 0])

# Padding
# In absolute units:
pa = plot(D, x=:x, y=:y, gp, xscale, style(plot_padding=[10,10,5,5].*mm))
# In relative units (relative to width & height of plot):
pb = plot(D, x=:x, y=:y, gp, xscale, style(plot_padding=[0.05w,0.05w,0.2h,0.2h]))
# 1mm padding on all sides, note x-axis right label gets cut deliberately:
pc = plot(D, x=:x, y=:y, gp, xscale, style(plot_padding=[1mm]))
hstack(pa,pb,pc)

```
![issue1018](https://user-images.githubusercontent.com/18226881/34452667-ebaa2304-ed98-11e7-8027-1c5c574c8bae.png)
