### PR TITLE
Geom.violin with color

### DIFF
--- a/docs/src/lib/geoms/geom_violin.md
+++ b/docs/src/lib/geoms/geom_violin.md
@@ -13,6 +13,7 @@ Aesthetics used directly:
   * `x`: Group categorically on the X-axis
   * `y`: Y-axis position.
   * `width`: Density at a given `y` value.
+  * `color` (optional): Violin color.  A suitable discrete variable is needed here. See example below.
 
 With the default statistic [Stat.violin](@ref), only the following need be defined:
 
@@ -29,5 +30,7 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 ```
 
 ```@example 1
-plot(dataset("lattice", "singer"), x="VoicePart", y="Height", Geom.violin)
+Dsing = dataset("lattice","singer")
+Dsing[:Voice] = [x[1:5] for x in Dsing[:VoicePart]]
+plot(Dsing, x=:VoicePart, y=:Height, color=:Voice, Geom.violin)
 ```

--- a/test/testscripts/violin.jl
+++ b/test/testscripts/violin.jl
@@ -2,4 +2,4 @@ using Gadfly, DataArrays, RDatasets
 
 set_default_plot_size(6inch, 3inch)
 
-plot(dataset("lattice", "singer"), x=:VoicePart, y=:Height, Geom.violin)
+plot(dataset("lattice", "singer"), x=:VoicePart, y=:Height, color=:VoicePart, Geom.violin)


### PR DESCRIPTION
Enables mapping violin color to a suitable variable (#1074).
An example:
```Julia
using DataFrames
group = ["S","A","T"]
D = vcat([DataFrame( y=(j-1)+randn(20), x=g*"$j", group=g)  for j in 1:2, g in group]...)
plot(D, x=:x, y=:y, Geom.violin, color=:group)
```
![issue1074](https://user-images.githubusercontent.com/18226881/34484126-d46ea702-f016-11e7-97cb-0c4f38222771.png)
