### PR TITLE
Guide.colorkey with labels

### DIFF
--- a/docs/src/dev/pipeline.md
+++ b/docs/src/dev/pipeline.md
@@ -66,7 +66,7 @@ p = plot(layer(df,
 		 Coord.cartesian,
 		 Guide.xticks, Guide.yticks,
 		 Guide.xlabel("Price"),
-		 Guide.colorkey("Cut"))
+		 Guide.colorkey(title="Cut"))
 ```
 
 Once a full plot specification is filled out, the rendering process proceeds as follows:

--- a/docs/src/lib/geoms/geom_vectorfield.md
+++ b/docs/src/lib/geoms/geom_vectorfield.md
@@ -39,7 +39,7 @@ plot(coord, z=(x,y)->x*exp(-(x^2+y^2)),
         Geom.vectorfield(scale=0.4, samples=17), Geom.contour(levels=6),
         Scale.x_continuous(minvalue=-2.0, maxvalue=2.0),
         Scale.y_continuous(minvalue=-2.0, maxvalue=2.0),
-        Guide.xlabel("x"), Guide.ylabel("y"), Guide.colorkey("z")
+        Guide.xlabel("x"), Guide.ylabel("y"), Guide.colorkey(title="z")
     )
 ```
 

--- a/docs/src/lib/guides/guide_colorkey.md
+++ b/docs/src/lib/guides/guide_colorkey.md
@@ -1,23 +1,29 @@
 ```@meta
-Author = "Daniel C. Jones"
+Author = "Daniel C. Jones. Additions by Mattriks"
 ```
 
 # Guide.colorkey
 
-Set the title for the plot legend
+`Guide.colorkey` enables control of some fields of the auto-generated colorkey. Currently, you can change the colorkey title (for any plot), and the item labels (for plots with a discrete color scale). The fields can be named e.g. `Guide.colorkey(title="Group", labels=["A","B"])`, or given in order e.g. `Guide.colorkey("Group", ["A","B"])`.
 
 ## Arguments
-  * `title`: Legend title
+  * `title`: Legend title (for any plot)
+  * `labels`: Legend item labels (for plots with a discrete color scale)
 
 ## Examples
 
 ```@setup 1
 using RDatasets
 using Gadfly
-Gadfly.set_default_plot_size(14cm, 8cm)
+Gadfly.set_default_plot_size(14cm, 7cm)
 ```
 
 ```@example 1
-volcano = float(convert(Array, dataset("datasets", "volcano")))
-plot(z=volcano, Geom.contour, Guide.colorkey("Elevation"))
+Dsleep = dataset("ggplot2", "msleep")[[:Vore,:BrainWt,:BodyWt,:SleepTotal]]
+completecases!(Dsleep)
+Dsleep[:SleepTime] = Dsleep[:SleepTotal] .> 8
+plot(Dsleep, x=:BodyWt, y=:BrainWt, Geom.point, color=:SleepTime, 
+    Guide.colorkey(title="Sleep \n(hours/day)\n ", labels=[">8","≤8"]),
+    Scale.x_log10, Scale.y_log10 )
+
 ```

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -170,8 +170,13 @@ end
 
 immutable ColorKey <: Gadfly.GuideElement
     title::Union{AbstractString, (Void)}
+    labels::Union{Vector{String}, (Void)}
 end
-ColorKey() = ColorKey(nothing)
+ColorKey(;title=nothing, labels=nothing) = ColorKey(title, labels)
+
+@deprecate ColorKey(title) ColorKey(title=title)
+
+# ColorKey() = ColorKey(nothing)
 
 const colorkey = ColorKey
 
@@ -414,6 +419,10 @@ function render(guide::ColorKey, theme::Gadfly.Theme,
     end
 
     color_key_labels = aes.color_label(keys(aes.color_key_colors))
+    if !continuous_guide && (guide.labels != nothing)
+        color_key_labels = guide.labels
+    end
+
     for (color, label) in zip(keys(aes.color_key_colors), color_key_labels)
         if !in(color, used_colors)
             push!(used_colors, color)

--- a/src/poetry.jl
+++ b/src/poetry.jl
@@ -62,7 +62,7 @@ function plot(f::Function, xmin::Number, xmax::Number, ymin::Number, ymax::Numbe
     end
 
     if !in(Guide.ColorKey, element_types) && !in(Guide.ManualColorKey, element_types)
-        push!(default_elements, Guide.colorkey("f(x,y)"))
+        push!(default_elements, Guide.colorkey(title="f(x,y)"))
     end
 
     push!(default_elements, Coord.cartesian(xflip=xmin > xmax, yflip=ymin > ymax))

--- a/test/testscripts/Guide_colorkey.jl
+++ b/test/testscripts/Guide_colorkey.jl
@@ -1,0 +1,6 @@
+using Gadfly
+
+set_default_plot_size(6inch, 3inch)
+
+plot(x=rand(20), y=rand(20), color=repeat(["A","B"], inner=10),
+     Guide.colorkey(title="Species",labels=["Name1","Name2"]))

--- a/test/testscripts/explicit_colorkey_title.jl
+++ b/test/testscripts/explicit_colorkey_title.jl
@@ -1,6 +1,0 @@
-using Gadfly
-
-set_default_plot_size(6inch, 3inch)
-
-plot(x=rand(20), y=rand(20), color=vcat(fill("A", 10), fill("B", 10)),
-     Guide.colorkey("Species"))

--- a/test/testscripts/vector.jl
+++ b/test/testscripts/vector.jl
@@ -16,7 +16,7 @@ plot(z=(x,y)->x*exp(-(x^2+y^2)),
         Geom.vectorfield(scale=0.4, samples=17),
         Scale.x_continuous(minvalue=-2.0, maxvalue=2.0),
         Scale.y_continuous(minvalue=-2.0, maxvalue=2.0),
-        Guide.xlabel("x"), Guide.ylabel("y"), Guide.colorkey("z")
+        Guide.xlabel("x"), Guide.ylabel("y"), Guide.colorkey(title="z")
     )
 
 Z = fill(1.0, 5, 5)


### PR DESCRIPTION
This PR enables adds new functionality for `Guide.colorkey` (#940, #1084):
* Adds a new field `Guide.colorkey(labels=[])`
* Exposes `Guide.colorkey` as an outer function, so it can take named arguments:
 `Guide.colorkey(title="", labels=["",""])`
* Plus I've updated the doc pages and all uses of `Guide.colorkey()` in `Gadfly`.

An example (second plot uses new colorkey):
```Julia
using RDatasets
Dsleep = dataset("ggplot2", "msleep")[[:Vore,:BrainWt,:BodyWt,:SleepTotal]]
completecases!(Dsleep)
Dsleep[:SleepTime] = Dsleep[:SleepTotal] .> 8

# Plot a: auto-generated key
pa = plot(Dsleep, x=:BodyWt, y=:BrainWt, Geom.point, color=:SleepTime,
    Scale.x_log10, Scale.y_log10 )

# Plot b: with new colorkey
pb = plot(Dsleep, x=:BodyWt, y=:BrainWt, Geom.point, color=:SleepTime, 
    Guide.colorkey(title="Sleep \n(hours/day)\n ", labels=[">8","≤8"]),
    Scale.x_log10, Scale.y_log10 )
```

![issue1084a](https://user-images.githubusercontent.com/18226881/34596565-fd05b000-f234-11e7-8011-a8e5cf0f708c.png)
This addresses the issue noted [here](https://github.com/GiovineItalia/Gadfly.jl/issues/940#issuecomment-338427274), so function labels can now be changed:
![issue1084b](https://user-images.githubusercontent.com/18226881/34596581-10e1a1f6-f235-11e7-92ed-4a425407c4c3.png)

