### PR TITLE
add difference images to regression testing

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,5 @@
 RDatasets
 Cairo
 Fontconfig
+Rsvg
+Images

--- a/test/compare_examples.jl
+++ b/test/compare_examples.jl
@@ -1,17 +1,35 @@
-using Base.Test, Compat
+using Base.Test, Rsvg, Cairo, Images
+
+if !isempty(ARGS)
+    regex_filter = Regex(ARGS[1])
+end
+
+function svg2img(filename)
+  r = Rsvg.handle_new_from_file(filename)
+  d = Rsvg.handle_get_dimensions(r)
+  cs = Cairo.CairoImageSurface(d.width,d.height,Cairo.FORMAT_ARGB32)
+  c = Cairo.CairoContext(cs)
+  Rsvg.handle_render_cairo(c,r)
+  fout = tempname()
+  Cairo.write_to_png(cs,fout)
+  png = load(fout)
+  rm(fout)
+  png
+end
 
 # Compare with cached output
 cachedout = joinpath((@__DIR__), "cachedoutput")
 gennedout = joinpath((@__DIR__), "gennedoutput")
 ndifferentfiles = 0
 const creator_producer = r"(Creator|Producer)"
-for file in filter(x->x[1]!='.', readdir(cachedout))
+for file in filter(x->!startswith(x,"git."), readdir(cachedout))
+    isdefined(:regex_filter) && !ismatch(regex_filter,file) && continue
     print("Comparing ", file, " ... ")
     cached = open(readlines, joinpath(cachedout, file))
     genned = open(readlines, joinpath(gennedout, file))
-    same = (n=length(cached)) == length(genned)
+    same = length(cached) == length(genned)
     if same
-        lsame = Bool[cached[i] == genned[i] for i = 1:n]
+        lsame = Bool[cached[i] == genned[i] for i = 1:length(cached)]
         if !all(lsame)
             for idx in find(lsame.==false)
                 # Don't worry about lines that are due to
@@ -28,12 +46,25 @@ for file in filter(x->x[1]!='.', readdir(cachedout))
     else
         ndifferentfiles +=1
         println("different :(")
-        println(readstring(ignorestatus(
-                `diff $(joinpath(cachedout, file)) $(joinpath(gennedout, file))`)))
+        run(ignorestatus(`diff $(joinpath(cachedout, file)) $(joinpath(gennedout, file))`))
         run(`open $(joinpath(cachedout,file))`)
         run(`open $(joinpath(gennedout,file))`)
+        if endswith(file,".svg")
+            gimg = svg2img(joinpath(gennedout,file));
+            cimg = svg2img(joinpath(cachedout,file));
+        elseif endswith(file,".png")
+            gimg = load(joinpath(gennedout,file));
+            cimg = load(joinpath(cachedout,file));
+        end
+        if endswith(file,".svg") || endswith(file,".png")
+            dimg = convert(Matrix{Gray}, gimg.==cimg)
+            fout = joinpath(tempdir(),file*".png")
+            Images.save(fout, dimg)
+            run(`open $fout`)
+        end
         println("Press the return/enter key to continue")
         readline()
+        (endswith(file,".svg") || endswith(file,".png")) && rm(fout)
     end
 end
 @test ndifferentfiles==0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,5 +113,5 @@ end
 if !haskey(ENV, "TRAVIS") && !isinteractive() &&
             !isempty(readdir(joinpath((@__DIR__),"cachedoutput"))) &&
             !isempty(readdir(joinpath((@__DIR__),"gennedoutput")))
-    run(`$(Base.julia_cmd()) compare_examples.jl`)  # `include`ing causes it to hang.
+    run(`$(Base.julia_cmd()) compare_examples.jl`)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,9 @@ end
 using Gadfly, Compat
 
 repo = LibGit2.GitRepo(dirname(@__DIR__))
-outputdir = in(LibGit2.headname(repo)[1:6], ["master","(detac"]) ? "cachedoutput" : "gennedoutput"
+branch = LibGit2.headname(repo)
+outputdir = mapreduce(x->startswith(branch,x), |, ["master","(detac"]) ?
+        "cachedoutput" : "gennedoutput"
 
 if VERSION>=v"0.6"
     function mimic_git_log_n1(io::IO, head)


### PR DESCRIPTION
in addition to opening corresponding test images created by master and your development branch to manually visually compare, `runtests.jl`, via `compare_examples.jl`, will now also create a black and white image of the difference between the two to facilitate quicker comparison.  currently works for SVG and PNG, and not PGF or PDF.