### PR TITLE
DataFrames 0.11+ compat via IndirectArrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,7 @@ script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("Gadfly");'
   - julia -e 'Pkg.checkout("Compose")'
-  # because of a bug in Julia 0.6.2 we temporarily use --compilecache=no.
-  # The bug is fixed on master and will be included in 0.6.3 so when it
-  # has been releases, we can bump the requirement and remove the flag.
-  - julia --check-bounds=yes --compilecache=no -e 'Pkg.test("Gadfly", coverage=true)'
+  - julia --check-bounds=yes -e 'Pkg.test("Gadfly", coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("Gadfly")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
   - julia -e 'Pkg.checkout("Compose")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,17 @@ matrix:
     - julia: nightly
 notifications:
   email: false
+matrix:
+  allow_failures:
+  - julia: nightly
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("Gadfly");'
   - julia -e 'Pkg.checkout("Compose")'
-  - julia --check-bounds=yes -e 'Pkg.test("Gadfly", coverage=true)'
+  # because of a bug in Julia 0.6.2 we temporarily use --compilecache=no.
+  # The bug is fixed on master and will be included in 0.6.3 so when it
+  # has been releases, we can bump the requirement and remove the flag.
+  - julia --check-bounds=yes --compilecache=no -e 'Pkg.test("Gadfly", coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("Gadfly")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
   - julia -e 'Pkg.checkout("Compose")'

--- a/REQUIRE
+++ b/REQUIRE
@@ -16,5 +16,10 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
-IndirectArrays 0.4
+IndirectArrays 0.4.1
 Missings
+# Gadfly doesn't use WeakRefString directly but because of a but in Julia 0.6.2, Gadfly
+# will trigger a ambiguity error between WeakRefString methods. A temporary method was
+# added in version WeakRefStrings 0.4.3 to work around this. When Gadfly requires at least
+# Julia 0.6.3, this dependency can therefore be dropped.
+WeakRefStrings 0.4.3

--- a/REQUIRE
+++ b/REQUIRE
@@ -16,5 +16,5 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
-IndirectArrays
+IndirectArrays 0.4
 Missings

--- a/REQUIRE
+++ b/REQUIRE
@@ -18,7 +18,7 @@ StatsBase
 Juno
 IndirectArrays 0.4.1
 Missings
-# Gadfly doesn't use WeakRefString directly but because of a but in Julia 0.6.2, Gadfly
+# Gadfly doesn't use WeakRefString directly but because of a bug in Julia 0.6.2, Gadfly
 # will trigger a ambiguity error between WeakRefString methods. A temporary method was
 # added in version WeakRefStrings 0.4.3 to work around this. When Gadfly requires at least
 # Julia 0.6.3, this dependency can therefore be dropped.

--- a/REQUIRE
+++ b/REQUIRE
@@ -16,5 +16,5 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
-PooledArrays
+IndirectArrays
 Missings

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,10 +1,10 @@
-julia 0.5
+julia 0.6
 Colors 0.3.4
 Compat 0.18.0
 Compose 0.5.2
 Contour 0.1.1
 CoupledFields
-DataFrames 0.4.2 0.11.0
+DataFrames 0.11.4
 DataArrays
 DataStructures
 Distributions
@@ -16,3 +16,5 @@ Loess
 Showoff 0.0.3
 StatsBase
 Juno
+PooledArrays
+Missings

--- a/docs/src/lib/scales/scale_x_discrete.md
+++ b/docs/src/lib/scales/scale_x_discrete.md
@@ -19,7 +19,7 @@ easiest way to get that data to plot appropriately.
     should map a value in `x` to a string giving its label.
   * `levels`: If non-nothing, give values for the scale. Order will be respected
     and anything in the data that's not respresented in `levels` will be set to
-    `NA`.
+    `missing`.
   * `order`: If non-nothing, give a vector of integers giving a permutation of
     the values pool of the data.
 

--- a/docs/src/lib/scales/scale_y_discrete.md
+++ b/docs/src/lib/scales/scale_y_discrete.md
@@ -19,7 +19,7 @@ easiest way to get that data to plot appropriately.
     should map a value in `x` to a string giving its label.
   * `levels`: If non-nothing, give values for the scale. Order will be respected
     and anything in the data that's not respresented in `levels` will be set to
-    `NA`.
+    `missing`.
   * `order`: If non-nothing, give a vector of integers giving a permutation of
     the values pool of the data.
 

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -10,7 +10,7 @@ using DataFrames
 using DataStructures
 using JSON
 using Showoff
-using PooledArrays
+using IndirectArrays
 using CategoricalArrays
 
 import IterTools
@@ -37,17 +37,6 @@ export Plot, Layer, Theme, Col, Row, Scale, Coord, Geom, Guide, Stat, Shape, ren
 @deprecate octogon Shape.octogon
 @deprecate hline Shape.hline
 @deprecate vline Shape.vline
-
-# Things that should go into other packages.
-# (Probably in a more efficient version)
-## PooledArrays
-function Base.append!(x::PooledArray{T,R,N,RA}, y::PooledArray{T,R,N,RA}) where {T,R,N,RA}
-    if x.pool == y.pool
-        append!(x.refs, y.refs)
-        return x
-    end
-    throw(ArgumentError("pools not identical"))
-end
 
 # Re-export some essentials from Compose
 export SVGJS, SVG, PGF, PNG, PS, PDF, draw, inch, mm, cm, px, pt, color, @colorant_str, vstack, hstack, title, gridstack
@@ -1126,7 +1115,7 @@ end
 
 import Juno: Juno, @render, media, Media
 
-media(Plot, Media.Plot)
+# media(Plot, Media.Plot)
 
 @render Juno.PlotPane p::Plot begin
     x, y = Juno.plotsize()
@@ -1232,9 +1221,9 @@ end
 
 # Determine whether the input is categorical or numerical
 
-const CategoricalType = Union{AbstractString, Bool, Symbol}
+const CategoricalType = Union{AbstractString, Bool, Symbol, CategoricalArrays.CategoricalValue, CategoricalArrays.CategoricalString}
 
-classify_data{N, T <: CategoricalType}(data::AbstractArray{T, N}) = :categorical
+classify_data{N, T <: Union{CategoricalType,Missing}}(data::AbstractArray{T, N})        = :categorical
 classify_data{N, T <: Union{Base.Callable,Measure,Colorant}}(data::AbstractArray{T, N}) = :functional
 classify_data{T <: Base.Callable}(data::T) = :functional
 classify_data(data::AbstractArray) = :numerical

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -11,6 +11,7 @@ using DataStructures
 using JSON
 using Showoff
 using PooledArrays
+using CategoricalArrays
 
 import IterTools
 import IterTools: distinct, drop, chain

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -1221,10 +1221,11 @@ end
 
 # Determine whether the input is categorical or numerical
 
-const CategoricalType = Union{AbstractString, Bool, Symbol, CategoricalArrays.CategoricalValue, CategoricalArrays.CategoricalString}
+const CategoricalType = Union{AbstractString, Bool, Symbol}
 
 classify_data{N, T <: Union{CategoricalType,Missing}}(data::AbstractArray{T, N})        = :categorical
 classify_data{N, T <: Union{Base.Callable,Measure,Colorant}}(data::AbstractArray{T, N}) = :functional
+classify_data(data::CategoricalArray) = :categorical
 classify_data{T <: Base.Callable}(data::T) = :functional
 classify_data(data::AbstractArray) = :numerical
 classify_data(data::Distribution) = :distribution

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -1115,7 +1115,7 @@ end
 
 import Juno: Juno, @render, media, Media
 
-# media(Plot, Media.Plot)
+media(Plot, Media.Plot)
 
 @render Juno.PlotPane p::Plot begin
     x, y = Juno.plotsize()

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -10,6 +10,7 @@ using DataFrames
 using DataStructures
 using JSON
 using Showoff
+using PooledArrays
 
 import IterTools
 import IterTools: distinct, drop, chain
@@ -35,6 +36,17 @@ export Plot, Layer, Theme, Col, Row, Scale, Coord, Geom, Guide, Stat, Shape, ren
 @deprecate octogon Shape.octogon
 @deprecate hline Shape.hline
 @deprecate vline Shape.vline
+
+# Things that should go into other packages.
+# (Probably in a more efficient version)
+## PooledArrays
+function Base.append!(x::PooledArray{T,R,N,RA}, y::PooledArray{T,R,N,RA}) where {T,R,N,RA}
+    if x.pool == y.pool
+        append!(x.refs, y.refs)
+        return x
+    end
+    throw(ArgumentError("pools not identical"))
+end
 
 # Re-export some essentials from Compose
 export SVGJS, SVG, PGF, PNG, PS, PDF, draw, inch, mm, cm, px, pt, color, @colorant_str, vstack, hstack, title, gridstack

--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -288,20 +288,6 @@ function cat_aes_var!{T, U}(a::AbstractArray{T}, b::AbstractArray{U})
     return ab
 end
 
-function cat_aes_var!{T}(xs::PooledDataVector{T}, ys::PooledDataVector{T})
-    newpool = T[x for x in union(Set(xs.values), Set(ys.values))]
-    newdata = vcat(T[x for x in xs], T[y for y in ys])
-    IndirectArray(newdata, newpool)
-end
-
-function cat_aes_var!{T, U}(xs::PooledDataVector{T}, ys::PooledDataVector{U})
-    V = promote_type(T, U)
-    newpool = V[x for x in union(Set(xs.values), Set(ys.values))]
-    newdata = vcat(V[x for x in xs], V[y for y in ys])
-    IndirectArray(newdata, newpool)
-end
-
-
 # Summarizing aesthetics
 
 # Produce a matrix of Aesthetic or Data objects partitioning the original

--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -1,8 +1,8 @@
 const NumericalOrCategoricalAesthetic =
-    Union{(Void), Vector, DataArray, PooledDataArray}
+    Union{(Void), Vector, DataArray, PooledArray}
 
 const CategoricalAesthetic =
-    Union{(Void), PooledDataArray}
+    Union{(Void), PooledArray}
 
 const NumericalAesthetic =
     Union{(Void), Matrix, Vector, DataArray}
@@ -290,14 +290,14 @@ end
 function cat_aes_var!{T}(xs::PooledDataVector{T}, ys::PooledDataVector{T})
     newpool = T[x for x in union(Set(xs.pool), Set(ys.pool))]
     newdata = vcat(T[x for x in xs], T[y for y in ys])
-    PooledDataArray(newdata, newpool, [false for _ in newdata])
+    PooledArray(newdata, newpool)
 end
 
 function cat_aes_var!{T, U}(xs::PooledDataVector{T}, ys::PooledDataVector{U})
     V = promote_type(T, U)
     newpool = V[x for x in union(Set(xs.pool), Set(ys.pool))]
     newdata = vcat(V[x for x in xs], V[y for y in ys])
-    PooledDataArray(newdata, newpool, [false for _ in newdata])
+    PooledArray(newdata, newpool)
 end
 
 
@@ -333,10 +333,10 @@ function by_xy_group{T <: Union{Data, Aesthetics}}(aes::T, xgroup, ygroup,
 
     xgroup === nothing && ygroup === nothing && return aes_grid
 
-    make_pooled_data_array{T,U,V}(::Type{PooledDataArray{T,U,V}}, arr::AbstractArray) =
-            PooledDataArray(convert(Array{T}, arr))
-    make_pooled_data_array{T,U,V}(::Type{PooledDataArray{T,U,V}},
-            arr::PooledDataArray{T,U,V}) = arr
+    make_pooled_array{T,R,N,RA}(::Type{PooledArray{T,R,N,RA}}, arr::AbstractArray) =
+            PooledArray(convert(Array{T}, arr))
+    make_pooled_array{T,R,N,RA}(::Type{PooledArray{T,R,N,RA}},
+            arr::PooledArray{T,R,N,RA}) = arr
 
     for var in fieldnames(T)
         # Skipped aesthetics. Don't try to partition aesthetics for which it
@@ -366,9 +366,9 @@ function by_xy_group{T <: Union{Data, Aesthetics}}(aes::T, xgroup, ygroup,
             end
 
             for i in 1:n, j in 1:m
-                if typeof(vals) <: PooledDataArray
+                if typeof(vals) <: PooledArray
                     setfield!(aes_grid[i, j], var,
-                              make_pooled_data_array(typeof(vals), staging[i, j]))
+                              make_pooled_array(typeof(vals), staging[i, j]))
                 else
                     if !applicable(convert, typeof(vals), staging[i, j])
                         T2 = eltype(vals)

--- a/src/geom/bar.jl
+++ b/src/geom/bar.jl
@@ -76,7 +76,7 @@ function render_stacked_bar(geom::BarGeometry,
                                      aes::Gadfly.Aesthetics,
                                      orientation::Symbol)
     # preserve factor orders of pooled data arrays
-    if isa(aes.color, PooledDataArray)
+    if isa(aes.color, PooledArray)
         idxs = sortperm(aes.color.refs, rev=true)
     else
         idxs = 1:length(aes.color)
@@ -152,7 +152,7 @@ function render_dodged_bar(geom::BarGeometry,
                                     aes::Gadfly.Aesthetics,
                                     orientation::Symbol)
     # preserve factor orders of pooled data arrays
-    if isa(aes.color, PooledDataArray)
+    if isa(aes.color, PooledArray)
         idxs = sortperm(aes.color.refs, rev=true)
     else
         idxs = 1:length(aes.color)

--- a/src/geom/bar.jl
+++ b/src/geom/bar.jl
@@ -76,8 +76,8 @@ function render_stacked_bar(geom::BarGeometry,
                                      aes::Gadfly.Aesthetics,
                                      orientation::Symbol)
     # preserve factor orders of pooled data arrays
-    if isa(aes.color, PooledArray)
-        idxs = sortperm(aes.color.refs, rev=true)
+    if isa(aes.color, IndirectArray)
+        idxs = sortperm(aes.color.index, rev=true)
     else
         idxs = 1:length(aes.color)
     end
@@ -152,8 +152,8 @@ function render_dodged_bar(geom::BarGeometry,
                                     aes::Gadfly.Aesthetics,
                                     orientation::Symbol)
     # preserve factor orders of pooled data arrays
-    if isa(aes.color, PooledArray)
-        idxs = sortperm(aes.color.refs, rev=true)
+    if isa(aes.color, IndirectArray)
+        idxs = sortperm(aes.color.index, rev=true)
     else
         idxs = 1:length(aes.color)
     end

--- a/src/geom/beeswarm.jl
+++ b/src/geom/beeswarm.jl
@@ -16,7 +16,7 @@ function render(geom::BeeswarmGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthet
     Gadfly.assert_aesthetics_equal_length("Geom.point", aes,
                                           element_aesthetics(geom)...)
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledArray(RGBA{Float32}[theme.default_color])
+    default_aes.color = IndirectArray(RGBA{Float32}[theme.default_color])
     default_aes.size = Measure[theme.point_size]
     aes = inherit(aes, default_aes)
     padding = 1.0mm

--- a/src/geom/beeswarm.jl
+++ b/src/geom/beeswarm.jl
@@ -16,7 +16,7 @@ function render(geom::BeeswarmGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthet
     Gadfly.assert_aesthetics_equal_length("Geom.point", aes,
                                           element_aesthetics(geom)...)
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledDataArray(RGBA{Float32}[theme.default_color])
+    default_aes.color = PooledArray(RGBA{Float32}[theme.default_color])
     default_aes.size = Measure[theme.point_size]
     aes = inherit(aes, default_aes)
     padding = 1.0mm

--- a/src/geom/boxplot.jl
+++ b/src/geom/boxplot.jl
@@ -27,7 +27,7 @@ function render(geom::BoxplotGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
                                      :upper_hinge, :upper_fence, :outliers)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledArray(RGB{Float32}[theme.default_color])
+    default_aes.color = IndirectArray(RGB{Float32}[theme.default_color])
     default_aes.x = Float64[0.5]
     aes = inherit(aes, default_aes)
 

--- a/src/geom/boxplot.jl
+++ b/src/geom/boxplot.jl
@@ -27,7 +27,7 @@ function render(geom::BoxplotGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
                                      :upper_hinge, :upper_fence, :outliers)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledDataArray(RGB{Float32}[theme.default_color])
+    default_aes.color = PooledArray(RGB{Float32}[theme.default_color])
     default_aes.x = Float64[0.5]
     aes = inherit(aes, default_aes)
 

--- a/src/geom/errorbar.jl
+++ b/src/geom/errorbar.jl
@@ -54,7 +54,7 @@ function render(geom::YErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthe
                                           element_aesthetics(geom)...)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledDataArray(RGB{Float32}[theme.default_color])
+    default_aes.color = PooledArray(RGB{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
     caplen = theme.errorbar_cap_length/2
     ttc, teb, tbc = subtags(geom.tag, :top_cap, :error_bar, :bottom_cap)
@@ -95,7 +95,7 @@ function render(geom::XErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthe
 
     colored = aes.color != nothing
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledDataArray(RGB{Float32}[theme.default_color])
+    default_aes.color = PooledArray(RGB{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
     caplen = theme.errorbar_cap_length/2
     tlc, teb, trc = subtags(geom.tag, :left_cap, :error_bar, :right_cap)

--- a/src/geom/errorbar.jl
+++ b/src/geom/errorbar.jl
@@ -54,7 +54,7 @@ function render(geom::YErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthe
                                           element_aesthetics(geom)...)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledArray(RGB{Float32}[theme.default_color])
+    default_aes.color = IndirectArray(RGB{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
     caplen = theme.errorbar_cap_length/2
     ttc, teb, tbc = subtags(geom.tag, :top_cap, :error_bar, :bottom_cap)
@@ -95,7 +95,7 @@ function render(geom::XErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthe
 
     colored = aes.color != nothing
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledArray(RGB{Float32}[theme.default_color])
+    default_aes.color = IndirectArray(RGB{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
     caplen = theme.errorbar_cap_length/2
     tlc, teb, trc = subtags(geom.tag, :left_cap, :error_bar, :right_cap)

--- a/src/geom/hexbin.jl
+++ b/src/geom/hexbin.jl
@@ -16,7 +16,7 @@ element_aesthetics(geom::HexagonalBinGeometry) = [:x, :y, :xsize, :ysize, :color
 
 function render(geom::HexagonalBinGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledDataArray(RGB{Float32}[theme.default_color])
+    default_aes.color = PooledArray(RGB{Float32}[theme.default_color])
     default_aes.xsize = [1.0]
     default_aes.ysize = [1.0]
     aes = inherit(aes, default_aes)
@@ -25,7 +25,7 @@ function render(geom::HexagonalBinGeometry, theme::Gadfly.Theme, aes::Gadfly.Aes
     Gadfly.assert_aesthetics_equal_length("Geom.hexbin", aes, :x, :y)
 
     n = length(aes.x)
-    visibility = Bool[!isna(c) for c in takestrict(cycle(aes.color), n)]
+    visibility = Bool[!ismissing(c) for c in takestrict(cycle(aes.color), n)]
     xs = aes.x[visibility]
     ys = aes.y[visibility]
     xsizes = collect(eltype(aes.xsize), takestrict(cycle(aes.xsize), n))[visibility]

--- a/src/geom/hexbin.jl
+++ b/src/geom/hexbin.jl
@@ -16,7 +16,7 @@ element_aesthetics(geom::HexagonalBinGeometry) = [:x, :y, :xsize, :ysize, :color
 
 function render(geom::HexagonalBinGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledArray(RGB{Float32}[theme.default_color])
+    default_aes.color = IndirectArray(RGB{Float32}[theme.default_color])
     default_aes.xsize = [1.0]
     default_aes.ysize = [1.0]
     aes = inherit(aes, default_aes)

--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -58,7 +58,7 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
                                           element_aesthetics(geom)...)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledArray(RGBA{Float32}[theme.default_color])
+    default_aes.color = IndirectArray(RGBA{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
 
     ctx = context(order=geom.order)
@@ -132,7 +132,7 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
                       svgclass("geometry"))
 
     elseif length(aes.color) == 1 &&
-            !(isa(aes.color, PooledArray) && length(levels(aes.color)) > 1)
+            !(isa(aes.color, IndirectArray) && length(levels(aes.color)) > 1)
         T = (Tuple{eltype(aes.x), eltype(aes.y)})
         points = T[(x, y) for (x, y) in zip(aes.x, aes.y)]
         geom.preserve_order || sort!(points, by=first)

--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -58,7 +58,7 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
                                           element_aesthetics(geom)...)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledDataArray(RGBA{Float32}[theme.default_color])
+    default_aes.color = PooledArray(RGBA{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
 
     ctx = context(order=geom.order)
@@ -132,7 +132,7 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
                       svgclass("geometry"))
 
     elseif length(aes.color) == 1 &&
-            !(isa(aes.color, PooledDataArray) && length(levels(aes.color)) > 1)
+            !(isa(aes.color, PooledArray) && length(levels(aes.color)) > 1)
         T = (Tuple{eltype(aes.x), eltype(aes.y)})
         points = T[(x, y) for (x, y) in zip(aes.x, aes.y)]
         geom.preserve_order || sort!(points, by=first)

--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -132,7 +132,7 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
                       svgclass("geometry"))
 
     elseif length(aes.color) == 1 &&
-            !(isa(aes.color, IndirectArray) && length(filter(!ismissing, aes.color.values)) > 1)
+            !(isa(aes.color, IndirectArray) && count(!ismissing, aes.color.values) > 1)
         T = (Tuple{eltype(aes.x), eltype(aes.y)})
         points = T[(x, y) for (x, y) in zip(aes.x, aes.y)]
         geom.preserve_order || sort!(points, by=first)

--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -132,7 +132,7 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
                       svgclass("geometry"))
 
     elseif length(aes.color) == 1 &&
-            !(isa(aes.color, IndirectArray) && length(levels(aes.color)) > 1)
+            !(isa(aes.color, IndirectArray) && length(filter(!ismissing, aes.color.values)) > 1)
         T = (Tuple{eltype(aes.x), eltype(aes.y)})
         points = T[(x, y) for (x, y) in zip(aes.x, aes.y)]
         geom.preserve_order || sort!(points, by=first)

--- a/src/geom/point.jl
+++ b/src/geom/point.jl
@@ -25,7 +25,7 @@ function render(geom::PointGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
 
     default_aes = Gadfly.Aesthetics()
     default_aes.shape = Function[Shape.circle]
-    default_aes.color = PooledDataArray(RGBA{Float32}[theme.default_color])
+    default_aes.color = PooledArray(RGBA{Float32}[theme.default_color])
     default_aes.size = Measure[theme.point_size]
     aes = inherit(aes, default_aes)
 

--- a/src/geom/point.jl
+++ b/src/geom/point.jl
@@ -25,7 +25,7 @@ function render(geom::PointGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
 
     default_aes = Gadfly.Aesthetics()
     default_aes.shape = Function[Shape.circle]
-    default_aes.color = PooledArray(RGBA{Float32}[theme.default_color])
+    default_aes.color = IndirectArray(RGBA{Float32}[theme.default_color])
     default_aes.size = Measure[theme.point_size]
     aes = inherit(aes, default_aes)
 

--- a/src/geom/polygon.jl
+++ b/src/geom/polygon.jl
@@ -38,7 +38,7 @@ function render(geom::PolygonGeometry, theme::Gadfly.Theme,
     Gadfly.assert_aesthetics_defined("Geom.polygon", aes, :x, :y)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledDataArray(RGBA{Float32}[theme.default_color])
+    default_aes.color = PooledArray(RGBA{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
 
     ctx = context(order=geom.order)
@@ -66,7 +66,7 @@ function render(geom::PolygonGeometry, theme::Gadfly.Theme,
             compose!(ctx, fill(nothing), stroke(cs))
         end
     elseif length(aes.color) == 1 &&
-            !(isa(aes.color, PooledDataArray) && length(levels(aes.color)) > 1)
+            !(isa(aes.color, PooledArray) && length(levels(aes.color)) > 1)
         compose!(ctx, Compose.polygon(polygon_points(aes.x, aes.y, geom.preserve_order), geom.tag))
         if geom.fill
             compose!(ctx, fill(aes.color[1]),

--- a/src/geom/polygon.jl
+++ b/src/geom/polygon.jl
@@ -38,7 +38,7 @@ function render(geom::PolygonGeometry, theme::Gadfly.Theme,
     Gadfly.assert_aesthetics_defined("Geom.polygon", aes, :x, :y)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledArray(RGBA{Float32}[theme.default_color])
+    default_aes.color = IndirectArray(RGBA{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
 
     ctx = context(order=geom.order)
@@ -66,7 +66,7 @@ function render(geom::PolygonGeometry, theme::Gadfly.Theme,
             compose!(ctx, fill(nothing), stroke(cs))
         end
     elseif length(aes.color) == 1 &&
-            !(isa(aes.color, PooledArray) && length(levels(aes.color)) > 1)
+            !(isa(aes.color, IndirectArray) && length(levels(aes.color)) > 1)
         compose!(ctx, Compose.polygon(polygon_points(aes.x, aes.y, geom.preserve_order), geom.tag))
         if geom.fill
             compose!(ctx, fill(aes.color[1]),

--- a/src/geom/polygon.jl
+++ b/src/geom/polygon.jl
@@ -66,7 +66,7 @@ function render(geom::PolygonGeometry, theme::Gadfly.Theme,
             compose!(ctx, fill(nothing), stroke(cs))
         end
     elseif length(aes.color) == 1 &&
-            !(isa(aes.color, IndirectArray) && length(levels(aes.color)) > 1)
+            !(isa(aes.color, IndirectArray) && length(filter(!ismissing, aes.color.values)) > 1)
         compose!(ctx, Compose.polygon(polygon_points(aes.x, aes.y, geom.preserve_order), geom.tag))
         if geom.fill
             compose!(ctx, fill(aes.color[1]),

--- a/src/geom/rectbin.jl
+++ b/src/geom/rectbin.jl
@@ -42,7 +42,7 @@ element_aesthetics(::RectangularBinGeometry) =
 function render(geom::RectangularBinGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledDataArray(RGBA{Float32}[theme.default_color])
+    default_aes.color = PooledArray(RGBA{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
 
     Gadfly.assert_aesthetics_defined("RectangularBinGeometry", aes, :xmin, :xmax, :ymin, :ymax)

--- a/src/geom/rectbin.jl
+++ b/src/geom/rectbin.jl
@@ -42,7 +42,7 @@ element_aesthetics(::RectangularBinGeometry) =
 function render(geom::RectangularBinGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledArray(RGBA{Float32}[theme.default_color])
+    default_aes.color = IndirectArray(RGBA{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
 
     Gadfly.assert_aesthetics_defined("RectangularBinGeometry", aes, :xmin, :xmax, :ymin, :ymax)

--- a/src/geom/ribbon.jl
+++ b/src/geom/ribbon.jl
@@ -23,7 +23,7 @@ function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
     aes_x, aes_ymin, aes_ymax = concretize(aes.x, aes.ymin, aes.ymax)
 
     if length(aes.color) == 1 &&
-        !(isa(aes.color, IndirectArray) && length(levels(aes.color)) > 1)
+        !(isa(aes.color, IndirectArray) && length(filter(!ismissing, aes.color.values)) > 1)
         max_points = collect(zip(aes_x, aes_ymax))
         sort!(max_points, by=first)
 

--- a/src/geom/ribbon.jl
+++ b/src/geom/ribbon.jl
@@ -17,13 +17,13 @@ function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
                                           element_aesthetics(geom)...)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledArray(RGB{Float32}[theme.default_color])
+    default_aes.color = IndirectArray(RGB{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
 
     aes_x, aes_ymin, aes_ymax = concretize(aes.x, aes.ymin, aes.ymax)
 
     if length(aes.color) == 1 &&
-        !(isa(aes.color, PooledArray) && length(levels(aes.color)) > 1)
+        !(isa(aes.color, IndirectArray) && length(levels(aes.color)) > 1)
         max_points = collect(zip(aes_x, aes_ymax))
         sort!(max_points, by=first)
 

--- a/src/geom/ribbon.jl
+++ b/src/geom/ribbon.jl
@@ -17,13 +17,13 @@ function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
                                           element_aesthetics(geom)...)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = PooledDataArray(RGB{Float32}[theme.default_color])
+    default_aes.color = PooledArray(RGB{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
 
     aes_x, aes_ymin, aes_ymax = concretize(aes.x, aes.ymin, aes.ymax)
 
     if length(aes.color) == 1 &&
-        !(isa(aes.color, PooledDataArray) && length(levels(aes.color)) > 1)
+        !(isa(aes.color, PooledArray) && length(levels(aes.color)) > 1)
         max_points = collect(zip(aes_x, aes_ymax))
         sort!(max_points, by=first)
 

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -8,7 +8,7 @@ using DataStructures
 using Distributions
 using Gadfly
 using Measures
-using PooledArrays
+using IndirectArrays
 
 import Compose.combine # Prevent DataFrame.combine from taking over.
 import Gadfly: render, layers, element_aesthetics, inherit, escape_id,

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -8,6 +8,7 @@ using DataStructures
 using Distributions
 using Gadfly
 using Measures
+using PooledArrays
 
 import Compose.combine # Prevent DataFrame.combine from taking over.
 import Gadfly: render, layers, element_aesthetics, inherit, escape_id,

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -1,20 +1,7 @@
 #Is this usable data?
-isconcrete{T<:Number}(x::T) = !isna(x) && isfinite(x)
+isconcrete{T<:Number}(x::T) = !ismissing(x) && isfinite(x)
 isconcrete(x::(Irrational)) = true
-isconcrete(x) = !isna(x)
-
-hasna(xs) = false
-
-function hasna(xs::AbstractDataArray)
-    for x in xs
-        if isna(x)
-            return true
-        end
-    end
-    return false
-end
-
-
+isconcrete(x) = !ismissing(x)
 
 function isallconcrete(xs)
     ans = true

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -342,16 +342,6 @@ end
 
 svg_color_class_from_label(label::AbstractString) = @sprintf("color_%s", escape_id(label))
 
-
-
-"""
-A faster map function for PooledDataVector
-"""
-function pooled_map(T::Type, f::Function, xs::PooledDataVector)
-    newpool = T[f(x) for x in xs.pool]
-    return T[newpool[i] for i in xs.refs]
-end
-
 using Base.Dates
 
 # Arbitrarily order colors

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -208,18 +208,6 @@ function concrete_minmax{T<:Real}(xs::IterTools.Chain, xmin::T, xmax::T)
 end
 
 
-
-function nonzero_length(xs)
-    n = 0
-    for x in xs
-        if x != 0
-            n += 1
-        end
-    end
-    n
-end
-
-
 # Create a new object of type T from a with missing values (i.e., those set to
 # nothing) inherited from b.
 function inherit{T}(a::T, b::T)

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -495,7 +495,9 @@ function apply_scale(scale::DiscreteColorScale,
     for (aes, data) in zip(aess, datas)
         data.color === nothing && continue
         for d in data.color
-            push!(levelset, d)
+            # Remove missing values
+            # FixMe! The handling of missing values shouldn't be this scattered across the source
+            ismissing(d) || push!(levelset, d)
         end
     end
 
@@ -514,15 +516,11 @@ function apply_scale(scale::DiscreteColorScale,
 
     for (aes, data) in zip(aess, datas)
         data.color === nothing && continue
-        ds = discretize(data.color, scale_levels)
-        colorvals = Array{RGB{Float32}}(count(!iszero, ds.index))
-        i = 1
-        for k in ds.index
-            if k != 0
-                colorvals[i] = colors[k]
-                i += 1
-            end
-        end
+        # Remove missing values
+        # FixMe! The handling of missing values shouldn't be this scattered across the source
+        ds = discretize([c for c in data.color if !ismissing(c)], scale_levels)
+
+        colorvals = colors[ds.index]
 
         colored_ds = IndirectArray(colorvals, colors)
         aes.color = colored_ds

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -283,7 +283,6 @@ discretize_make_pda(values::IndirectArray, levels) =
 discretize_make_pda(values::CategoricalArray)         = discretize_make_pda(values, unique(values))
 discretize_make_pda(values::CategoricalArray, ::Void) = discretize_make_pda(values)
 function discretize_make_pda(values::CategoricalArray{T}, levels::Vector) where {T}
-    # _values = map!(t -> ismissing(t) ? t : get(t), Array{T}(size(values)...), values)
     index = map!(t -> ismissing(t) ?
                     findfirst(ismissing, levels) :
                         findfirst(s -> !(ismissing(s) || s != get(t)), levels),
@@ -294,6 +293,11 @@ function discretize_make_pda(values::CategoricalArray{T}, levels::CategoricalVec
     _levels = map!(t -> ismissing(t) ? t : get(t), Vector{T}(length(levels)), levels)
     discretize_make_pda(values, _levels)
 end
+
+# These methods convert WeakRefStringArrays to Vector{String} and shouldn't really be necessary
+# since it has been decided that WeakRefStrings shouldn't be used externally anymore
+discretize_make_pda(s::AbstractArray{<:AbstractString}) = discretize_make_pda(Vector{String}(s))
+discretize_make_pda(s::AbstractArray{<:AbstractString}, levels) = discretize_make_pda(Vector{String}(s), levels)
 
 function discretize(values, levels=nothing, order=nothing, preserve_order=true)
     if levels == nothing

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -8,6 +8,7 @@ using DataStructures
 using Gadfly
 using Showoff
 using PooledArrays
+using CategoricalArrays
 
 import Gadfly: element_aesthetics, isconcrete, concrete_length,
                nonzero_length
@@ -284,7 +285,7 @@ function discretize_make_pda(values::Range, levels=nothing)
     end
 end
 
-function discretize_make_pda(values::PooledArray, levels=nothing)
+function discretize_make_pda(values::Union{PooledArray,CategoricalArray}, levels=nothing)
     if levels == nothing
         return values
     else

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -174,6 +174,9 @@ function apply_scale(scale::ContinuousScale,
     for (aes, data) in zip(aess, datas)
         for var in scale.vars
             vals = getfield(data, var)
+            if vals isa CategoricalArray
+                throw(ArgumentError("continuous scale for $var aesthetic when stored as a CategoricalArray. Consider using a discrete scale or convert data to an Array."))
+            end
             vals === nothing && continue
 
             # special case for function arrays bound to :y

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -10,8 +10,7 @@ using Showoff
 using IndirectArrays
 using CategoricalArrays
 
-import Gadfly: element_aesthetics, isconcrete, concrete_length,
-               nonzero_length
+import Gadfly: element_aesthetics, isconcrete, concrete_length
 import Distributions: Distribution
 
 include("color_misc.jl")
@@ -516,7 +515,7 @@ function apply_scale(scale::DiscreteColorScale,
     for (aes, data) in zip(aess, datas)
         data.color === nothing && continue
         ds = discretize(data.color, scale_levels)
-        colorvals = Array{RGB{Float32}}(nonzero_length(ds.index))
+        colorvals = Array{RGB{Float32}}(count(!iszero, ds.index))
         i = 1
         for k in ds.index
             if k != 0

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -254,7 +254,7 @@ end
 
 # Reorder the levels of a pooled data array
 function reorder_levels(da::IndirectArray, order::AbstractVector)
-    level_values = levels(da)
+    level_values = da.values
     length(order) != length(level_values) &&
             error("Discrete scale order is not of the same length as the data's levels.")
     permute!(level_values, order)
@@ -377,7 +377,7 @@ function apply_scale(scale::DiscreteScale, aess::Vector{Gadfly.Aesthetics}, data
             # The leveler for discrete scales is a closure over the discretized data.
             if scale.labels === nothing
                 function default_labeler(xs)
-                    lvls = levels(disc_data)
+                    lvls = filter(!ismissing, disc_data.values)
                     vals = Any[1 <= x <= length(lvls) ? lvls[x] : "" for x in xs]
                     if all([isa(val, AbstractFloat) for val in vals])
                         return showoff(vals)
@@ -388,7 +388,7 @@ function apply_scale(scale::DiscreteScale, aess::Vector{Gadfly.Aesthetics}, data
                 labeler = default_labeler
             else
                 function explicit_labeler(xs)
-                    lvls = levels(disc_data)
+                    lvls = filter(!ismissing, disc_data.values)
                     return [string(scale.labels(lvls[x])) for x in xs]
                 end
                 labeler = explicit_labeler

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1873,7 +1873,7 @@ function Gadfly.Stat.apply_statistic(stat::EllipseStatistic,
         end
     end
 
-    aes.group = PooledDataArray(levels)
+    aes.group = IndirectArray(levels)
     colorflag && (aes.color = colors)
     aes.x = ellipse_x
     aes.y = ellipse_y

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -987,7 +987,7 @@ function apply_statistic(stat::BoxplotStatistic,
 
         if aes.color !== nothing
             aes.color = IndirectArray([c for (x, c) in groups],
-                                        filter(!ismissing, aes.color.values))
+                                      filter(!ismissing, aes.color.values))
         end
 
         return

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -987,7 +987,7 @@ function apply_statistic(stat::BoxplotStatistic,
 
         if aes.color !== nothing
             aes.color = IndirectArray([c for (x, c) in groups],
-                                        levels(aes.color))
+                                        filter(!ismissing, aes.color.values))
         end
 
         return
@@ -1072,7 +1072,7 @@ function apply_statistic(stat::BoxplotStatistic,
 
     if aes.color !== nothing
         aes.color = IndirectArray(RGB{Float32}[c for (x, c) in keys(groups)],
-                                    levels(aes.color))
+                                    aes.color.levels)
     end
 
     nothing

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -15,7 +15,7 @@ using CoupledFields # It is registered in METADATA.jl
 using IndirectArrays
 
 import Gadfly: Scale, Coord, input_aesthetics, output_aesthetics,
-               default_scales, isconcrete, nonzero_length, setfield!
+               default_scales, isconcrete, setfield!
 import KernelDensity
 # import Distributions: Uniform, Distribution, qqbuild
 import IterTools: chain, distinct

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -12,6 +12,7 @@ using Distributions
 using Hexagons
 using Loess
 using CoupledFields # It is registered in METADATA.jl
+using PooledArrays
 
 import Gadfly: Scale, Coord, input_aesthetics, output_aesthetics,
                default_scales, isconcrete, nonzero_length, setfield!
@@ -400,7 +401,7 @@ function apply_statistic(stat::HistogramStatistic,
             end
         end
 
-        aes.color = PooledDataArray(colors)
+        aes.color = PooledArray(colors)
     end
 
     getfield(aes, viewminvar) === nothing && setfield!(aes, viewminvar, 0.0)
@@ -527,7 +528,7 @@ function apply_statistic(stat::DensityStatistic,
                 push!(colors, c)
             end
         end
-        aes.color = PooledDataArray(colors)
+        aes.color = PooledArray(colors)
     end
     aes.y_label = Gadfly.Scale.identity_formatter
 end
@@ -666,13 +667,13 @@ function apply_statistic(stat::Histogram2DStatistic,
 
     if x_categorial
         aes.xmin, aes.xmax = barminmax(aes.x, false)
-        aes.x = PooledDataArray(aes.x)
+        aes.x = PooledArray(aes.x)
         aes.pad_categorical_x = Nullable(false)
     end
 
     if y_categorial
         aes.ymin, aes.ymax = barminmax(aes.y, false)
-        aes.y = PooledDataArray(aes.y)
+        aes.y = PooledArray(aes.y)
         aes.pad_categorical_y = Nullable(false)
     end
 
@@ -986,7 +987,7 @@ function apply_statistic(stat::BoxplotStatistic,
         end
 
         if aes.color !== nothing
-            aes.color = PooledDataArray([c for (x, c) in groups],
+            aes.color = PooledArray([c for (x, c) in groups],
                                         levels(aes.color))
         end
 
@@ -1066,12 +1067,12 @@ function apply_statistic(stat::BoxplotStatistic,
         end
     end
 
-    if isa(aes_x, PooledDataArray)
-        aes.x = PooledDataArray(aes.x, aes_x.pool)
+    if isa(aes_x, PooledArray)
+        aes.x = PooledArray(aes.x, aes_x.pool)
     end
 
     if aes.color !== nothing
-        aes.color = PooledDataArray(RGB{Float32}[c for (x, c) in keys(groups)],
+        aes.color = PooledArray(RGB{Float32}[c for (x, c) in keys(groups)],
                                     levels(aes.color))
     end
 
@@ -1156,7 +1157,7 @@ function apply_statistic(stat::SmoothStatistic,
     end
 
     if !(aes.color===nothing)
-        aes.color = PooledDataArray(colors)
+        aes.color = PooledArray(colors)
     end
 end
 
@@ -1343,7 +1344,7 @@ function apply_statistic(stat::FunctionStatistic,
             aes.color[1+(i-1)*stat.num_samples:i*stat.num_samples] = func_color[i]
             groups[1+(i-1)*stat.num_samples:i*stat.num_samples] = i
         end
-        aes.group = PooledDataArray(groups)
+        aes.group = PooledArray(groups)
     elseif length(aes.y) > 1 && haskey(scales, :color)
         data = Gadfly.Data()
         data.color = Array{AbstractString}(length(aes.y) * stat.num_samples)
@@ -1354,7 +1355,7 @@ function apply_statistic(stat::FunctionStatistic,
             groups[1+(i-1)*stat.num_samples:i*stat.num_samples] = i
         end
         Scale.apply_scale(scales[:color], [aes], data)
-        aes.group = PooledDataArray(groups)
+        aes.group = PooledArray(groups)
     end
 
     data = Gadfly.Data()
@@ -1417,7 +1418,7 @@ function apply_statistic(stat::ContourStatistic,
 
     stat_levels = typeof(stat.levels) <: Function ? stat.levels(zs) : stat.levels
 
-    groups = PooledDataArray(Int[])
+    groups = PooledArray(Int[])
     group = 0
     for level in Contour.levels(Contour.contours(xs, ys, zs, stat_levels))
         for line in Contour.lines(level)
@@ -1661,7 +1662,7 @@ function apply_statistic(stat::BinMeanStatistic,
                 push!(colors, c)
             end
         end
-        aes.color = PooledDataArray(colors)
+        aes.color = PooledArray(colors)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,8 @@ using Base.Test, Gadfly, Compat
 
 repo = LibGit2.GitRepo(dirname(@__DIR__))
 branch = LibGit2.headname(repo)
-outputdir = mapreduce(x->startswith(branch,x), |, ["master","(detac"]) ?
-        "cachedoutput" : "gennedoutput"
+outputdir = joinpath(@__DIR__, mapreduce(x->startswith(branch,x), |, ["master","(detac"]) ?
+        "cachedoutput" : "gennedoutput")
 
 if VERSION>=v"0.6"
     function mimic_git_log_n1(io::IO, head)
@@ -107,4 +107,10 @@ close(output)
 
 if prev_theme !== nothing
     ENV["GADFLY_THEME"] = prev_theme
+end
+
+if !haskey(ENV, "TRAVIS") && !isinteractive() &&
+            !isempty(readdir(joinpath((@__DIR__),"cachedoutput"))) &&
+            !isempty(readdir(joinpath((@__DIR__),"gennedoutput")))
+    run(`$(Base.julia_cmd()) $(joinpath(@__DIR__, "compare_examples.jl"))`)  # `include`ing causes it to hang.
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,9 +108,3 @@ close(output)
 if prev_theme !== nothing
     ENV["GADFLY_THEME"] = prev_theme
 end
-
-if !haskey(ENV, "TRAVIS") && !isinteractive() &&
-            !isempty(readdir(joinpath((@__DIR__),"cachedoutput"))) &&
-            !isempty(readdir(joinpath((@__DIR__),"gennedoutput")))
-    run(`$(Base.julia_cmd()) $(joinpath(@__DIR__, "compare_examples.jl"))`)  # `include`ing causes it to hang.
-end

--- a/test/testscripts/issue120.jl
+++ b/test/testscripts/issue120.jl
@@ -1,5 +1,5 @@
-using Gadfly, DataFrames, Compat
+using Gadfly, DataFrames, Compat, CSV
 
 set_default_plot_size(6inch, 3inch)
 
-plot(readtable(joinpath(dirname(@__DIR__), "data","issue120.csv")), x=:x1, y=:x2)
+plot(CSV.read(joinpath(dirname(@__DIR__), "data","issue120.csv")), x=:x1, y=:x2)

--- a/test/testscripts/issue82.jl
+++ b/test/testscripts/issue82.jl
@@ -2,5 +2,5 @@ using Gadfly, DataArrays, DataFrames
 
 set_default_plot_size(6inch, 3inch)
 
-a = DataFrame(diff = PooledArray(Float64[1,2,3,3,3,4,3,2]))
+a = DataFrame(diff = CategoricalArrays.CategoricalArray([1,2,3,3,3,4,3,2]))
 plot(a, x="diff", Geom.histogram)

--- a/test/testscripts/issue82.jl
+++ b/test/testscripts/issue82.jl
@@ -2,5 +2,5 @@ using Gadfly, DataArrays, DataFrames
 
 set_default_plot_size(6inch, 3inch)
 
-a = DataFrame(diff = PooledDataArray(Float64[1,2,3,3,3,4,3,2]))
+a = DataFrame(diff = PooledArray(Float64[1,2,3,3,3,4,3,2]))
 plot(a, x="diff", Geom.histogram)

--- a/test/testscripts/subplot_grid.jl
+++ b/test/testscripts/subplot_grid.jl
@@ -3,11 +3,7 @@ using RDatasets, DataArrays, DataFrames, Gadfly
 set_default_plot_size(10inch, 10inch)
 
 barley = dataset("lattice", "barley")
-if isdefined(:setlevels!)
-    setlevels!(barley[:Year], ["1931", "1932"])
-else
-    set_levels!(barley[:Year], ["1931", "1932"])
-end
+levels!(barley[:Year], ["1931", "1932"])
 
 idx = [startswith(x,"No.") for x in barley[:Variety]]
 plot(barley[idx,:],

--- a/test/testscripts/subplot_grid_free_axis.jl
+++ b/test/testscripts/subplot_grid_free_axis.jl
@@ -3,11 +3,7 @@ using RDatasets, DataArrays, DataFrames, Gadfly
 set_default_plot_size(10inch, 10inch)
 
 barley = dataset("lattice", "barley")
-if isdefined(:setlevels!)
-    setlevels!(barley[:Year], ["1931", "1932"])
-else
-    set_levels!(barley[:Year], ["1931", "1932"])
-end
+levels!(barley[:Year], ["1931", "1932"])
 
 idx = [startswith(x,"No.") for x in barley[:Variety]]
 plot(barley[idx,:],

--- a/test/testscripts/timeseries_year_2.jl
+++ b/test/testscripts/timeseries_year_2.jl
@@ -3,9 +3,11 @@ using Gadfly, DataArrays, RDatasets, Base.Dates
 set_default_plot_size(6inch, 3inch)
 
 economics = dataset("HistData", "Prostitutes")
-# NOTE: I know these aren't unix times, but I'm not sure what they are, and this
-# is just a test so it doesn't matter.
-dates = DateTime[unix2datetime(d) for d in economics[:Date]]
-economics[:Date] = dates
+
+if Pkg.installed("RData") < v"0.4.0"
+    # NOTE: I know these aren't unix times, but I'm not sure what they are, and this
+    # is just a test so it doesn't matter.
+    economics[:Date] = DateTime[unix2datetime(d) for d in economics[:Date]]
+end
 
 p = plot(economics, x=:Date, y=:Count, Geom.line)


### PR DESCRIPTION
@tlnagy Here is my version of the DataFrame 0.11+ compatible version. This version passes locally (see caveat below) with [this version of IndirectArrays](https://github.com/JuliaArrays/IndirectArrays.jl/pull/12). I decided that the wrapping behavior of CategoricalArrays was too inconvenient to get working with the current setup because it is implicitly assumed in most functions that "categorical" arrays return the same kand of values as non-categorical arrays. Maybe by restructuring the code to rely more on dispatch to smaller specialized methods it might be possible to use CategoricalArrays internally, but I'm not sure it is worth it. Basically, I don't think it is useful to have the `pool` handy for the use cases here in Gadfly.

Although the tests pass, it requires that Julia runs with `--compilecache=no`. Otherwise, it triggers what appears to be completely spurious ambiguity errors that we'd need @vtjnash or @JeffBezanson to comment on. It is hard for me to narrow down the issue but it could be related to `module`/`using`/`include`. E.g. I can trigger/detrigger the issue by including a file where all lines are commented. I've also been able to trigger/detrigger it with a `foo() = 1` definition in the middle of the `statistics.jl` file.