### PR TITLE
make Geom.point the default for layers too

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -424,6 +424,7 @@ function render_prepare(plot::Plot)
 
             evalmapping!(layer.mapping, layer.data_source, datas[i])
         end
+        if isa(layer.geom, Geom.Nil); layer.geom = Geom.point(); end # see #1062
     end
 
     # We need to process subplot layers somewhat as though they were regular

--- a/test/testscripts/layer_point_default.jl
+++ b/test/testscripts/layer_point_default.jl
@@ -1,0 +1,7 @@
+using Gadfly
+
+set_default_plot_size(6inch, 3inch)
+
+# these should both use Geom.point by default, see #1062
+plot(x=[1,2,3], y=[4,5,6])
+plot(layer(x=[1,2,3], y=[4,5,6]))


### PR DESCRIPTION
we already have Geom.point as the default when there are no layers. this
extends this to if no geometry is specified for a layer. Closes #1062