### PR TITLE
don't automatically call compare_examples; add flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ test/gennedoutput.html
 test/cachedoutput.html
 test/gennedoutput
 test/cachedoutput
+test/diffedoutput
 doc/html

--- a/docs/src/dev/regression.md
+++ b/docs/src/dev/regression.md
@@ -8,14 +8,15 @@ Running `Pkg.test("Gadfly")` evaluates all of the files in
 addition, the figures that are produced are put into either the `gennedoutput/`
 or `cachedoutput/` sub-directories.  Nominally, the former represents the
 changes in a pull request while the latter are used for comparison.
-Specifically, `runtests.jl` examines the currently checkout out git commit, and
+Specifically, `runtests.jl` examines the currently checked out git commit, and
 sets the output directory to `cachedoutput/` if it is the HEAD of the master
 branch or if it is detached.  Otherwise, it assumes you are at the tip of a
-development branch and saves the figures to `gennedoutput/`.  After evaluating
-all the test scripts, `runtests.jl` checks to see if both of the output
-directories are not empty.  If so, `compare_examples.jl` is called, and any
-differences between the new and old figures will be displayed in the REPL and
-the browser.
+development branch and saves the figures to `gennedoutput/`.  After running the
+tests on both of these branches, executing `compare_examples.jl` displays
+differences between the new and old figures.  This script can dump a diff of
+the files to the REPL, open both figures for manual comparison, and/or, for SVG
+and PNG files, display a black and white figure highlighting the spatial
+location of the differences.
 
 So the automated regression analysis workflow is then as follows:
 
@@ -25,4 +26,5 @@ So the automated regression analysis workflow is then as follows:
 4. `Pkg.test("Gadfly")`,
 5. checkout master,
 6. `Pkg.test` again,
-7. check that any of the reported differences are as intended.
+7. `Pkg.add("ArgParse")` and, for B&W images, Cairo, Fontconfig, Rsvg, and Images as well,
+8. check for differences with `julia test/compare_examples.jl [--diff] [--two] [--bw] [-h] [filter]`

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,3 @@
 RDatasets
 Cairo
 Fontconfig
-Rsvg
-Images

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,9 +108,3 @@ close(output)
 if prev_theme !== nothing
     ENV["GADFLY_THEME"] = prev_theme
 end
-
-if !haskey(ENV, "TRAVIS") && isinteractive() &&
-            length(readdir(joinpath((@__DIR__),"cachedoutput")))>1 &&
-            length(readdir(joinpath((@__DIR__),"gennedoutput")))>1
-    run(`$(Base.julia_cmd()) compare_examples.jl`)
-end


### PR DESCRIPTION
dang.  regression tests are still broken.

who would've thought that `runtests.jl` was non-interactive when called by `Pkg.test` and interactive when `include`d:

```
$ head -1 test/runtests.jl 
info(isinteractive());  exit()
```

```
julia> Pkg.test("Gadfly")
INFO: Computing test dependencies for Gadfly...
INFO: No packages to install, update or remove
INFO: Testing Gadfly
INFO: false
INFO: Gadfly tests passed
INFO: No packages to install, update or remove

julia> include("test/runtests.jl")
INFO: true
```

this PR should really fix `compare_examples.jl` now.  it also adds some nice flags to control its behavior.