### PR TITLE
grid_line_style

### DIFF
--- a/docs/src/man/themes.md
+++ b/docs/src/man/themes.md
@@ -44,6 +44,7 @@ These parameters can either be used with `Theme` or `style`
   * `grid_color_focused`: In the D3 backend, mousing over the plot makes the
     grid lines emphasised by transitioning to this color. (Color or Nothing)
   * `grid_line_width`: Width of grid lines. (Measure)
+  * `grid_line_style`: Style of grid lines. (Symbol in :solid, :dash, :dot, :dashdot, :dashdotdot, or Vector of Measures)   
   * `minor_label_font`: Font used for minor labels such as tick labels and entries
     in keys. (String)
   * `minor_label_font_size`: Font size used for minor labels. (Measure)
@@ -87,8 +88,8 @@ These parameters can either be used with `Theme` or `style`
   * `bar_highlight`: Color used to stroke bars in bar plots. If a function is
     given, it's used to transform the fill color of the bars to obtain a stroke
     color. (Function, Color, or Nothing)
-  * `discrete_color_scheme`: A `DiscreteColorScale` see [Scale.color_discrete_hue](@ref)
-  * `continuous_color_scheme`: A `ContinuousColorScale` see [Scale.color_continuous](@ref)
+  * `discrete_color_scale`: A `DiscreteColorScale` see [Scale.color_discrete_hue](@ref)
+  * `continuous_color_scale`: A `ContinuousColorScale` see [Scale.color_continuous](@ref)
 
 ## Examples
 

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -596,12 +596,13 @@ function render(guide::XTicks, theme::Gadfly.Theme,
     sum(gridvisibility) == 0 && sum(tickvisibility) == 0 && return PositionedGuide[]
 
     # grid lines
+    grid_line_style = Gadfly.get_stroke_vector(theme.grid_line_style)
     static_grid_lines = compose!(
         context(withoutjs=true),
         line([[(t, 0h), (t, 1h)] for t in grids[gridvisibility]]),
         stroke(theme.grid_color),
         linewidth(theme.grid_line_width),
-        strokedash(theme.grid_strokedash),
+        strokedash(grid_line_style),
         svgclass("guide xgridlines yfixed"))
 
     if dynamic
@@ -611,7 +612,7 @@ function render(guide::XTicks, theme::Gadfly.Theme,
             visible(gridvisibility),
             stroke(theme.grid_color),
             linewidth(theme.grid_line_width),
-            strokedash(theme.grid_strokedash),
+            strokedash(grid_line_style),
             svgclass("guide xgridlines yfixed"),
             svgattribute("gadfly:scale", scale),
             jsplotdata("focused_xgrid_color",
@@ -770,12 +771,13 @@ function render(guide::YTicks, theme::Gadfly.Theme,
     end
 
     # grid lines
+    grid_line_style = Gadfly.get_stroke_vector(theme.grid_line_style)
     static_grid_lines = compose!(
         context(withoutjs=true),
         line([[(0w, t), (1w, t)] for t in grids[gridvisibility]]),
         stroke(theme.grid_color),
         linewidth(theme.grid_line_width),
-        strokedash(theme.grid_strokedash),
+        strokedash(grid_line_style),
         svgclass("guide ygridlines xfixed"))
 
     if dynamic
@@ -785,7 +787,7 @@ function render(guide::YTicks, theme::Gadfly.Theme,
             visible(gridvisibility),
             stroke(theme.grid_color),
             linewidth(theme.grid_line_width),
-            strokedash(theme.grid_strokedash),
+            strokedash(grid_line_style),
             svgclass("guide ygridlines xfixed"),
             svgattribute("gadfly:scale", scale),
             jsplotdata("focused_ygrid_color",

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -97,7 +97,7 @@ end
 
     # Grid line color.
     grid_color,            ColorOrNothing,  colorant"#D0D0E0"
-    grid_strokedash,       Maybe(Vector),   [0.5mm, 0.5mm]
+    grid_line_style,       Union{Symbol,Vector},   [0.5mm, 0.5mm]
 
     # Grid lines for focused item.
     grid_color_focused,    ColorOrNothing,  colorant"#A0A0A0"

--- a/test/testscripts/grid_line_style.jl
+++ b/test/testscripts/grid_line_style.jl
@@ -3,5 +3,5 @@ using Gadfly, DataArrays, RDatasets
 set_default_plot_size(6inch, 3inch)
 
 plot(dataset("datasets", "iris"), x="SepalLength", y="SepalWidth",
-     Theme(grid_strokedash=[]),
+     Theme(grid_line_style=:solid),
      Geom.point)


### PR DESCRIPTION
This issue came up in this discourse [post](https://discourse.julialang.org/t/ggplot-style-background-in-gadfly/9722). I've now changed `Theme(grid_strokedash= )` to `Theme(grid_line_style= )`. The behaviour of `grid_line_style` matches the behaviour of `line_style` in Theme, plus I edited the Theme doc. 

```Julia
using Colors, RDatasets, Gadfly
palette(n::Int) = LCHuv.(65, 100, 15:(360/n):374)
colscale = Scale.color_discrete(palette)
ggplot_theme = Theme(panel_fill="gray90", grid_color="white", grid_line_style=:solid, discrete_color_scale=colscale)

p = plot(dataset("datasets","iris"), x=:PetalWidth, y=:SepalLength, color=:Species, Geom.point, ggplot_theme)
```
![themes](https://user-images.githubusercontent.com/18226881/37531530-928987ea-2990-11e8-88cf-c2a320404dd6.png)

Also, Gadfly currently has 2 named Themes: `:default` and `:dark`. Would anybody object to having another optional (not default) named Theme: `:ggplot`?
