### PR TITLE
fix problem with colors of different types

### DIFF
--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -289,8 +289,8 @@ end
 
 function cat_aes_var!(xs::IndirectArray{T,1}, ys::IndirectArray{S,1}) where {T, S}
     TS = promote_type(T, S)
-    return append!(IndirectArray(xs.index, Array{TS}(xs.values)),
-                   IndirectArray(ys.index, Array{TS}(ys.values)))
+    return append!(IndirectArray(xs.index, convert(Array{TS},xs.values)),
+                   IndirectArray(ys.index, convert(Array{TS},ys.values)))
 end
 
 # Summarizing aesthetics


### PR DESCRIPTION
@andreasnoack  having problem coming up with a minimal example to use as a test, but this fixed a problem for me which emitted the following error:

```
ERROR: TypeError: cat_aes_var!: in typeassert, expected Array{ColorTypes.Colorant{Float64,N} where N,N} where N, got Array{ColorTypes.RGB{Float64},1}
Stacktrace:
 [1] cat_aes_var!(::IndirectArrays.IndirectArray{ColorTypes.RGB{Float64},1,Array{UInt8,1},Array{ColorTypes.RGB{Float64},1}}, ::IndirectArrays.IndirectArray{ColorTypes.RGBA{Float64},1,Array{UInt8,1},Array{ColorTypes.RGBA{Float64},1}}) at /home/arthurb/.julia/v0.6/Gadfly/src/aesthetics.jl:292
 [2] concat(::Gadfly.Aesthetics, ::Vararg{Gadfly.Aesthetics,N} where N) at /home/arthurb/.julia/v0.6/Gadfly/src/aesthetics.jl:238
 [3] render_prepare(::Gadfly.Plot) at /home/arthurb/.julia/v0.6/Gadfly/src/Gadfly.jl:699
 [4] render(::Gadfly.Plot) at /home/arthurb/.julia/v0.6/Gadfly/src/Gadfly.jl:754
 [5] display(::Base.REPL.REPLDisplay{Base.REPL.LineEditREPL}, ::MIME{Symbol("text/html")}, ::Gadfly.Plot) at /home/arthurb/.julia/v0.6/Gadfly/src/Gadfly.jl:1068
 [6] display(::Base.REPL.REPLDisplay{Base.REPL.LineEditREPL}, ::Gadfly.Plot) at /home/arthurb/.julia/v0.6/Gadfly/src/Gadfly.jl:1013
 [7] display(::Gadfly.Plot) at ./multimedia.jl:194
 [8] hookless(::Media.##7#8{Gadfly.Plot}) at /home/arthurb/.julia/v0.6/Media/src/compat.jl:14
 [9] render(::Media.NoDisplay, ::Gadfly.Plot) at /home/arthurb/.julia/v0.6/Media/src/compat.jl:27
 [10] display(::Media.DisplayHook, ::Gadfly.Plot) at /home/arthurb/.julia/v0.6/Media/src/compat.jl:9
 [11] display(::Gadfly.Plot) at ./multimedia.jl:194
 [12] eval(::Module, ::Any) at ./boot.jl:235
 [13] print_response(::Base.Terminals.TTYTerminal, ::Any, ::Void, ::Bool, ::Bool, ::Void) at ./REPL.jl:144
 [14] print_response(::Base.REPL.LineEditREPL, ::Any, ::Void, ::Bool, ::Bool) at ./REPL.jl:129
 [15] (::Base.REPL.#do_respond#16{Bool,Base.REPL.##26#36{Base.REPL.LineEditREPL,Base.REPL.REPLHistoryProvider},Base.REPL.LineEditREPL,Base.LineEdit.Prompt})(::Base.LineEdit.MIState, ::Base.AbstractIOBuffer{Array{UInt8,1}}, ::Bool) at ./REPL.jl:646
```