### PR TITLE
fix SVG interactivity with error bars

### DIFF
--- a/src/geom/errorbar.jl
+++ b/src/geom/errorbar.jl
@@ -81,7 +81,7 @@ function render(geom::YErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthe
         stroke([theme.stroke_color(c) for c in aes.color]),
         linewidth(theme.line_width))
 
-    aes.color_key_continuous == true && compose!(ctx,
+    (aes.color_key_continuous == true || aes.color == nothing) || compose!(ctx,
             svgclass([svg_color_class_from_label(aes.color_label([c])[1]) for c in aes.color]))
 
     return ctx
@@ -93,7 +93,6 @@ function render(geom::XErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthe
     Gadfly.assert_aesthetics_equal_length("Geom.errorbar", aes,
                                           element_aesthetics(geom)...)
 
-    colored = aes.color != nothing
     default_aes = Gadfly.Aesthetics()
     default_aes.color = discretize_make_ia(RGB{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
@@ -122,7 +121,7 @@ function render(geom::XErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthe
         stroke([theme.stroke_color(c) for c in aes.color]),
         linewidth(theme.line_width))
 
-    (aes.color_key_continuous == true || !colored) && compose!(ctx,
+    (aes.color_key_continuous == true || aes.color == nothing) || compose!(ctx,
             svgclass([svg_color_class_from_label(aes.color_label([c])[1])
                       for c in aes.color]))
 


### PR DESCRIPTION
clicking and shift-clicking on legend entries now turns on and off the errorbars too, not just lines and points.