### PR TITLE
 Update DataFrames url in tutorial.md

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -9,7 +9,7 @@ graphics system for Julia. This tutorial will outline general usage
 patterns and will give you a feel for the overall system.
 
 To begin, we need some data. Gadfly works best when the data is supplied
-in a [DataFrame](https://juliastats.github.io/DataFrames.jl/stable/). In
+in a [DataFrame](https://juliadata.github.io/DataFrames.jl/stable/). In
 this tutorial, we'll pick and choose some examples from the
 [RDatasets](https://github.com/johnmyleswhite/RDatasets.jl) package.
 


### PR DESCRIPTION
DataFrames has moved from `juliastats` to `juliadata`. This commit will
update the url in tutorial.md.

<!-- Replace XXX with the issue number that this PR fixes, remove if there is no corresponding issue -->

# Contributor checklist:

<!-- Make sure to complete all of these that apply -->

- [x] I've updated the documentation to reflect these changes
- [ ] I've added an entry to `NEWS.md`
- [ ] I've added and/or updated the unit tests
- [ ] I've run the regression tests
- [x] I've `squash`'ed or `fixup`'ed junk commits with git-rebase
- [ ] I've built the docs and confirmed these changes don't cause new errors