### PR TITLE
Linestyle aes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ This is a log of major changes in Gadfly between releases. It is not exhaustive.
 Each release typically has a number of minor bug fixes beyond what is listed here.
 
 # Version 0.7.1
+  * Add `linestyle` aesthetic (#1181)
   * Add `Guide.shapekey` (#1156)
   * `Geom.contour`: add support for `DataFrame` (#1150) 
 

--- a/docs/src/gallery/geometries.md
+++ b/docs/src/gallery/geometries.md
@@ -136,7 +136,7 @@ pa = plot(D, coord,
 pb = plot(D, coord,
           x=:Eruptions, y=:Waiting, color=:g,
           Geom.point, Geom.ellipse,
-          layer(Geom.ellipse(levels=[0.99]), style(line_style=:dot)),
+          layer(Geom.ellipse(levels=[0.99]), style(line_style=[:dot])),
           style(key_position=:none), Guide.ylabel(nothing))
 hstack(pa,pb)
 ```

--- a/docs/src/gallery/scales.md
+++ b/docs/src/gallery/scales.md
@@ -97,6 +97,27 @@ p2 = plot(x=xs, y=ys, z=zs, Geom.contour, Scale.color_none);
 hstack(p1,p2)
 ```
 
+## [`Scale.linestyle_discrete`](@ref)
+
+```@example
+using DataFrames, Gadfly, RDatasets
+using StatsBase: winsor
+set_default_plot_size(18cm, 8cm)
+
+labs = [ "exp", "sqrt", "log", "winsor", "linear"]
+funcs = [ x->60*(1-exp.(-0.2*x)), x->sqrt.(x)*10, x->log.(x)*10, x->winsor(x, prop=0.15), x->x*0.6 ]
+x = [1.0:30;]
+D = vcat([DataFrame(x=x, y=f(x), linev=l) for (f,l) in zip(funcs, labs)]...)
+D[134:136,:y] = NaN
+
+p1 = plot(D, x=:x, y=:y, linestyle=:linev, Geom.line )
+p2 = plot(dataset("datasets", "CO2"), x=:Conc, y=:Uptake, 
+    group=:Plant, linestyle=:Treatment, color=:Type, Geom.line,
+    Scale.linestyle_discrete(order=[2,1]),
+    Theme(key_position=:top, key_title_font_size=-8mm) )
+hstack(p1,p2)
+```
+
 
 ## [`Scale.x_continuous`](@ref), [`Scale.y_continuous`](@ref)
 

--- a/docs/src/man/themes.md
+++ b/docs/src/man/themes.md
@@ -65,7 +65,7 @@ and can be used with `push_theme`, `with_theme`, and `plot`.
 ```@example 1
 Gadfly.push_theme(style(line_width=1mm))
 p1 = plot([sin,cos], 0, 2pi)
-p2 = plot([sin,cos], 0, 2pi, style(line_width=2mm, line_style=:dash))
+p2 = plot([sin,cos], 0, 2pi, style(line_width=2mm, line_style=[:dash]))
 fig = hstack(p1,p2)
 Gadfly.pop_theme()
 fig # hide

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -1152,7 +1152,8 @@ const default_aes_scales = Dict{Symbol, Dict}(
         :shape       => Scale.shape_discrete(),
         :size        => Scale.size_continuous(),
         :group       => Scale.group_discrete(),
-        :label       => Scale.label()
+        :label       => Scale.label(),
+        :linestyle   => Scale.linestyle_discrete()
     ),
 
     :categorical => Dict{Symbol, Any}(
@@ -1171,7 +1172,8 @@ const default_aes_scales = Dict{Symbol, Dict}(
         :shape      => Scale.shape_discrete(),
         :size       => Scale.size_discrete(),
         :group      => Scale.group_discrete(),
-        :label      => Scale.label()
+        :label      => Scale.label(),
+        :linestyle  => Scale.linestyle_discrete()
     )
 )
 

--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -18,6 +18,7 @@ const NumericalAesthetic =
     size,         Union{CategoricalAesthetic,Vector,Void}
     shape,        Union{CategoricalAesthetic,Vector,Void}
     color,        Union{CategoricalAesthetic,Vector,Void}
+    linestyle,    Union{CategoricalAesthetic,Vector,Void}
 
     label,        CategoricalAesthetic
     group,        CategoricalAesthetic

--- a/src/data.jl
+++ b/src/data.jl
@@ -32,6 +32,7 @@
     yviewmax
     size
     shape
+    linestyle
     xsize
     ysize
     color

--- a/src/geom/hvabline.jl
+++ b/src/geom/hvabline.jl
@@ -38,7 +38,7 @@ function render(geom::HLineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
 
     color = geom.color === nothing ? theme.default_color : geom.color
     size = geom.size === nothing ? theme.line_width : geom.size
-    style = geom.style === nothing ? theme.line_style : geom.style
+    style = geom.style === nothing ? theme.line_style[1] : geom.style
 
     color = check_arguments(color, length(aes.yintercept))
     size = check_arguments(size, length(aes.yintercept))
@@ -85,7 +85,7 @@ function render(geom::VLineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
 
     color = geom.color === nothing ? theme.default_color : geom.color
     size = geom.size === nothing ? theme.line_width : geom.size
-    style = geom.style === nothing ? theme.line_style : geom.style
+    style = geom.style === nothing ? theme.line_style[1] : geom.style
 
     color = check_arguments(color, length(aes.xintercept))
     size = check_arguments(size, length(aes.xintercept))
@@ -143,7 +143,7 @@ function render(geom::ABLineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
 
     color = geom.color === nothing ? theme.default_color : geom.color
     size = geom.size === nothing ? theme.line_width : geom.size
-    style = geom.style === nothing ? theme.line_style : geom.style
+    style = geom.style === nothing ? theme.line_style[1] : geom.style
 
     color = check_arguments(color, length(aes.intercept))
     size = check_arguments(size, length(aes.intercept))

--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -95,146 +95,73 @@ step(; direction::Symbol=:hv) = LineGeometry(Gadfly.Stat.step(direction=directio
 
 default_statistic(geom::LineGeometry) = geom.default_statistic
 
-element_aesthetics(::LineGeometry) = [:x, :y, :color, :group]
+element_aesthetics(::LineGeometry) = [:x, :y, :color, :group, :linestyle]
 
-function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
+
+
+
+
+function Gadfly.Geom.render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     Gadfly.assert_aesthetics_defined("Geom.line", aes, :x, :y)
-    Gadfly.assert_aesthetics_equal_length("Geom.line", aes,
-                                          element_aesthetics(geom)...)
+    Gadfly.assert_aesthetics_equal_length("Geom.line", aes, Geom.element_aesthetics(geom)...)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = discretize_make_ia(RGBA{Float32}[theme.default_color])
-    aes = inherit(aes, default_aes)
-
-    ctx = context(order=geom.order)
-    XT, YT, CT = eltype(aes.x), eltype(aes.y), eltype(aes.color)
-    XYT = Tuple{XT, YT}
-
-    line_style = Gadfly.get_stroke_vector(theme.line_style)
-
-    if aes.group != nothing
-        GT = eltype(aes.group)
-
-        if !geom.preserve_order
-            p = sortperm(aes.x)
-            aes_group = aes.group[p]
-            aes_color = length(aes.color) > 1 ? aes.color[p] : aes.color
-            aes_x = aes.x[p]
-            aes_y = aes.y[p]
-        else
-            aes_group = copy(aes.group)
-            aes_color = copy(aes.color)
-            aes_x = copy(aes.x)
-            aes_y = copy(aes.y)
-        end
-
-        # organize x, y pairs into lines
-        if length(aes_group) > length(aes_color)
-            p = sortperm(aes_group)
-        elseif length(aes_color) > length(aes_group)
-            p = sortperm(aes_color, lt=Gadfly.color_isless)
-        else
-            p = sortperm(collect((Tuple{GT, CT}),zip(aes_group, aes_color)),
-                         lt=Gadfly.group_color_isless)
-        end
-        permute!(aes_group, p)
-        permute!(aes_color, p)
-        permute!(aes_x, p)
-        permute!(aes_y, p)
-
-        points = Vector{XYT}[]
-        points_colors = CT[]
-        points_groups = GT[]
-
-        first_point = true
-        for (i, (x, y, c, g)) in enumerate(zip(aes_x, aes_y, cycle(aes_color), aes_group))
-            if !isconcrete(x) || !isconcrete(y)
-                first_point = true
-                continue
-            end
-
-            if i > 1 && (c != points_colors[end] || g != points_groups[end])
-                first_point = true
-            end
-
-            if first_point
-                push!(points, XYT[])
-                push!(points_colors, c)
-                push!(points_groups, g)
-                first_point = false
-            end
-
-            push!(points[end], (x, y))
-        end
-
-        classes = [svg_color_class_from_label(aes.color_label([c])[1])
-                   for (c, g) in zip(points_colors, points_groups)]
-
-        ctx = compose!(ctx, (context(), Compose.line(points,geom.tag),
-                        stroke(points_colors),
-                        strokedash(line_style),
-                        svgclass(classes)),
-                      svgclass("geometry"))
-
-    elseif length(aes.color) == 1 &&
-            !(isa(aes.color, IndirectArray) && count(!ismissing, aes.color.values) > 1)
-        T = (Tuple{eltype(aes.x), eltype(aes.y)})
-        points = T[(x, y) for (x, y) in zip(aes.x, aes.y)]
-        geom.preserve_order || sort!(points, by=first)
-        ctx = compose!(ctx, (context(), Compose.line([points],geom.tag),
-                       stroke(aes.color[1]),
-                       strokedash(line_style)),
-                       svgclass("geometry"))
-    else
-        if !geom.preserve_order
-            p = sortperm(aes.x)
-            aes_color = aes.color[p]
-            aes_x = aes.x[p]
-            aes_y = aes.y[p]
-        else
-            aes_color = copy(aes.color)
-            aes_x = copy(aes.x)
-            aes_y = copy(aes.y)
-        end
-
-        # organize x, y pairs into lines
-        p = sortperm(aes_color, lt=Gadfly.color_isless)
-        permute!(aes_color, p)
-        permute!(aes_x, p)
-        permute!(aes_y, p)
-
-        points = Vector{XYT}[]
-        points_colors = CT[]
-
-        first_point = true
-        for (i, (x, y, c)) in enumerate(zip(aes_x, aes_y, aes_color))
-            if !isconcrete(x) || !isconcrete(y)
-                first_point = true
-                continue
-            end
-
-            if isempty(points_colors) || c != points_colors[end]
-                first_point = true
-            end
-
-            if first_point
-                push!(points, XYT[])
-                push!(points_colors, c)
-                first_point = false
-            end
-
-            push!(points[end], (x, y))
-        end
-
-        classes = [svg_color_class_from_label(aes.color_label([c])[1])
-                   for c in points_colors]
-
-        ctx = compose!(ctx, (context(), Compose.line(points,geom.tag),
-                        stroke(points_colors),
-                        strokedash(line_style),
-                        svgclass(classes)),
-                      svgclass("geometry"))
+    default_aes.group = IndirectArray(fill(1,length(aes.x)))
+    default_aes.color = fill(theme.default_color, length(aes.x))
+    default_aes.linestyle = fill(1, length(aes.x))
+    aes = Gadfly.inherit(aes, default_aes)
+    
+    # Point order:
+    p = 1:length(aes.x)
+    !geom.preserve_order && (p = sortperm(aes.x))
+    aes_x, aes_y, aes_color, aes_g = aes.x[p], aes.y[p], aes.color[p], aes.group[p]
+    aes_linestyle = aes.linestyle[p]
+    
+    # Find the aesthetic with the most levels:
+    aesv = [aes_g, aes_color, aes_linestyle]
+    i1 = indmax([length(unique(a)) for a in aesv])
+    aes_maxlvls = aesv[i1]
+  
+    # Concrete values?:
+    cf = Gadfly.isconcrete.(aes_x) .& Gadfly.isconcrete.(aes_y)
+    fcf = .!cf
+    ulvls =  unique(aes_maxlvls[fcf])
+    aes_concrete = zeros(Int, length(cf))
+    for g in ulvls    
+        i = aes_maxlvls.==g
+        aes_concrete[i] = cumsum(fcf[i])
     end
+    
+    aes_x, aes_y, aes_color, aes_g = aes_x[cf], aes_y[cf], aes_color[cf], aes_g[cf]
+    aes_concrete, aes_linestyle = aes_concrete[cf], aes_linestyle[cf]
+    
+    # Render lines, using multivariate groupings:
+    XT, YT, CT, GT, CNT = eltype(aes_x), eltype(aes_y), eltype(aes_color), eltype(aes_g), eltype(aes_concrete)
+    LST = eltype(aes_linestyle)
+    groups = collect((Tuple{GT, CT, LST, CNT}), zip(aes_g, aes_color, aes_linestyle, aes_concrete))
+    ug = unique(groups)
 
+    n = length(ug)
+    lines = Vector{Vector{Tuple{XT,YT}}}(n)
+    line_colors = Vector{CT}(n)
+    line_styles = Vector{LST}(n)
+    linestyle_palette_length = length(theme.line_style)
+    for (k,g) in enumerate(ug)
+        i = groups.==[g]
+        lines[k] = collect(Tuple{XT,YT}, zip(aes_x[i], aes_y[i]))
+        line_colors[k] = first(aes_color[i])
+        line_styles[k] = mod1(first(aes_linestyle[i]), linestyle_palette_length) 
+    end
+    
+    linestyles =  Gadfly.get_stroke_vector.(theme.line_style[line_styles])
+    classes = svg_color_class_from_label.(aes.color_label(line_colors))
+    ctx = context(order=geom.order)
+    ctx = compose!(ctx, (context(), Compose.line(lines, geom.tag),
+                        stroke(line_colors),
+                        strokedash(linestyles),
+                        svgclass(classes)), svgclass("geometry")) 
+    
     return compose!(ctx, fill(nothing), linewidth(theme.line_width))
+
+
 end

--- a/src/geom/polygon.jl
+++ b/src/geom/polygon.jl
@@ -64,7 +64,7 @@ function render(geom::PolygonGeometry, theme::Gadfly.Theme,
     ctx = context(order=geom.order)
     T = (eltype(aes.x), eltype(aes.y))
 
-    line_style = Gadfly.get_stroke_vector(theme.line_style)
+    line_style = Gadfly.get_stroke_vector(theme.line_style[1])
 
     if aes.group != nothing
         XT, YT = eltype(aes.x), eltype(aes.y)

--- a/src/geom/segment.jl
+++ b/src/geom/segment.jl
@@ -76,7 +76,7 @@ function render(geom::SegmentGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
 
     aes = inherit(aes, default_aes) 
 
-    line_style = Gadfly.get_stroke_vector(theme.line_style)
+    line_style = Gadfly.get_stroke_vector(theme.line_style[1])
 
     # Geom.vector requires information about scales
 

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -304,8 +304,8 @@ anything in the data that's not respresented in `levels` will be set to
 `missing`.  `order` is a vector of integers giving a permutation of the levels
 default order.
 
-See also [`group_discrete`](@ref), [`shape_discrete`](@ref), and
-[`size_discrete`](@ref).
+See also [`group_discrete`](@ref), [`shape_discrete`](@ref), 
+[`size_discrete`](@ref), and [`linestyle_discrete`](@ref).
 """
 
 @doc xy_discrete_docstr("x", aes2str(element_aesthetics(x_discrete()))) x_discrete(; labels=nothing, levels=nothing, order=nothing) =
@@ -328,6 +328,10 @@ Similar to [`Scale.x_discrete`](@ref), except applied to the `$aes` aesthetic.
 
 @doc type_discrete_docstr("size") size_discrete(; labels=nothing, levels=nothing, order=nothing) =
         DiscreteScale([:size], labels=labels, levels=levels, order=order)
+
+@doc type_discrete_docstr("linestyle") linestyle_discrete(; labels=nothing, levels=nothing, order=nothing) =
+        DiscreteScale([:linestyle], labels=labels, levels=levels, order=order)
+
 
 function apply_scale(scale::DiscreteScale, aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
     for (aes, data) in zip(aess, datas)

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -47,15 +47,20 @@ default_middle_color(fill_color::TransparentColor) = RGBA{Float32}(
 get_stroke_vector(::Void) = []
 get_stroke_vector(vec::AbstractVector) = vec
 function get_stroke_vector(linestyle::Symbol)
-  dash = 4 * Compose.mm
-  dot = 2 * Compose.mm
-  gap = 1 * Compose.mm
-  linestyle == :solid && return []
-  linestyle == :dash && return [dash, gap]
-  linestyle == :dot && return [dot, gap]
-  linestyle == :dashdot && return [dash, gap, dot, gap]
-  linestyle == :dashdotdot && return [dash, gap, dot, gap, dot, gap]
-  error("unsupported linestyle: ", linestyle)
+    ldash = 6 * Compose.mm
+    dash = 4 * Compose.mm
+    dot = 2 * Compose.mm
+    gap = 1 * Compose.mm
+    linestyle == :solid && return []
+    linestyle == :dash && return [dash, gap]
+    linestyle == :dot && return [dot, gap]
+    linestyle == :dashdot && return [dash, gap, dot, gap]
+    linestyle == :dashdotdot && return [dash, gap, dot, gap, dot, gap]
+    linestyle == :ldash && return [ldash, gap]
+    linestyle == :ldashdash && return [ldash, gap, dash, gap]
+    linestyle == :ldashdot && return [ldash, gap, dot, gap]
+    linestyle == :ldashdashdot && return [ldash, gap, dash, gap, dot, gap]
+    error("unsupported linestyle: ", linestyle)
 end
 
 using DocStringExtensions
@@ -82,10 +87,9 @@ $(FIELDS)
     "Width of lines in the line geometry. (Measure)",
     line_width,            Measure,         0.3mm
 
-    # a Compose.StrokeDash object which takes a vector of sold/missing/solid/missing/... 
-    # lengths which are applied cyclically
-    "Style of lines in the line geometry. (Symbol in :solid, :dash, :dot, :dashdot, :dashdotdot, or Vector of Measures)",
-    line_style,            Union{Symbol,Vector},   :solid
+    "Style of lines in the line geometry. The default palette is `[:solid, :dash, :dot, :dashdot, :dashdotdot, :ldash, :ldashdash, :ldashdot, :ldashdashdot]` which is a Vector{Symbol}, or customize using Vector{Vector{<:Measure}}"
+    line_style,            (Vector{<:Union{Symbol, Vector{<:Measure}}}),   [:solid, :dash, :dot, :dashdot, :dashdotdot, 
+                                                    :ldash, :ldashdash, :ldashdot, :ldashdashdot  ]
 
     "Background color used in the main plot panel. (Color or Nothing)",
     panel_fill,            ColorOrNothing,  nothing

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -87,9 +87,8 @@ $(FIELDS)
     "Width of lines in the line geometry. (Measure)",
     line_width,            Measure,         0.3mm
 
-    "Style of lines in the line geometry. The default palette is `[:solid, :dash, :dot, :dashdot, :dashdotdot, :ldash, :ldashdash, :ldashdot, :ldashdashdot]` which is a Vector{Symbol}, or customize using Vector{Vector{<:Measure}}"
-    line_style,            (Vector{<:Union{Symbol, Vector{<:Measure}}}),   [:solid, :dash, :dot, :dashdot, :dashdotdot, 
-                                                    :ldash, :ldashdash, :ldashdot, :ldashdashdot  ]
+    "Style of lines in the line geometry. The default palette is `[:solid, :dash, :dot, :dashdot, :dashdotdot, :ldash, :ldashdash, :ldashdot, :ldashdashdot]` which is a Vector{Symbol}, or customize using Vector{Vector{<:Measure}}",
+    line_style,            (Vector{<:Union{Symbol, Vector{<:Measure}}}),   [:solid, :dash, :dot, :dashdot, :dashdotdot, :ldash, :ldashdash, :ldashdot, :ldashdashdot]
 
     "Background color used in the main plot panel. (Color or Nothing)",
     panel_fill,            ColorOrNothing,  nothing

--- a/test/testscripts/grouped_ellipse.jl
+++ b/test/testscripts/grouped_ellipse.jl
@@ -13,7 +13,7 @@ pa = plot(D, coord,
 pb = plot(D, coord,
     x=:Eruptions, y=:Waiting, color=:g,
     Geom.point, Geom.ellipse,
-    layer(Geom.ellipse(levels=[0.99]), style(line_style=:dot)),
+    layer(Geom.ellipse(levels=[0.99]), style(line_style=[:dot])),
     style(key_position=:none), Guide.ylabel(nothing)
 )
 hstack(pa,pb)

--- a/test/testscripts/line_linestyle.jl
+++ b/test/testscripts/line_linestyle.jl
@@ -1,0 +1,13 @@
+using DataFrames, Gadfly
+using StatsBase: winsor
+set_default_plot_size(6inch, 3inch)
+
+labs = [ "exp", "sqrt", "log", "winsor", "linear"]
+funcs = [ x->60*(1-exp.(-0.2*x)), x->sqrt.(x)*10, x->log.(x)*10, x->winsor(x, prop=0.15), x->x*0.6 ]
+x = [1.0:30;]
+D = vcat([DataFrame(x=x, y=f(x), linev=l) for (f,l) in zip(funcs, labs)]...)
+
+p1 = plot(D, x=:x, y=:y, linestyle=:linev, Geom.line )
+p2 = plot(D, x=:x, y=:y, linestyle=:linev, Geom.line,
+   Scale.linestyle_discrete(levels=["exp", "log", "sqrt", "linear", "winsor"]) )
+hstack(p1,p2)


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've `squash`'ed or `fixup`'ed junk commits with git-rebase
- [x] I've built the docs and confirmed these changes don't cause new errors
### Linestyle aes

This PR adds:
1. `linestyle` as an aesthetic (#455), not just as a Theme field (#392)
2. `Scale.linestyle_discrete`, so 1. & 2. are steps towards `Guide.linekey` (#1042)
3. A new `render(geom::LineGeometry)` function which fixes #903, and handles multiple aesthetics smoothly. 
4. Also closes #967, closes #755

Note that I'll do `Guide.linekey` in a separate PR.

### Examples:
```julia
labs = ["exp", "sqrt", "log", "winsor", "linear"]
funcs=[x->60*(1-exp.(-0.2*x)), x->sqrt.(x)*10, x->log.(x)*10, x->winsor(x, prop=0.15), x->x*0.6]
colors = ["α","α","β","γ","γ"] 
x = [1.0:30;]
D = vcat([DataFrame(x=x, y=f(x), linev=l, col=c) for (f,l,c) in zip(funcs, labs, colors)]...)
D[134:136,:y] = NaN

pa = plot(D, x=:x, y=:y, linestyle=:linev, Geom.line, Guide.title("linestyle=:linev"))
# Two aesthetics:
pb = plot(D, x=:x, y=:y, linestyle=:linev, color=:col, Geom.line,
   Scale.linestyle_discrete(levels=["exp", "log", "sqrt", "winsor", "linear"]),
    Guide.title("linestyle≠color"))
# Multiple aesthetics:
pc = plot(dataset("datasets", "CO2"), x=:Conc, y=:Uptake, 
    group=:Plant, linestyle=:Treatment, color=:Type, Geom.line,
    Scale.linestyle_discrete(order=[2,1]),
    Theme(key_position=:top, key_title_font_size=-5mm) )

hstack(pa,pb,pc)
```
![linestyle_a](https://user-images.githubusercontent.com/18226881/44299934-ff866680-a341-11e8-8993-0ee2d55f1383.png)




