### PR TITLE
remove strip to fix doc building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_script:
   - julia -e 'using Pkg; Pkg.add(PackageSpec(name="Compose", rev="master"))'
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-  - julia -e 'using Pkg; foreach(x->Pkg.add(strip(x)), readlines(open(joinpath("docs", "REQUIRE")))); include(joinpath("docs", "make.jl"))'
+  - julia -e 'using Pkg; foreach(x->Pkg.add(x), readlines(open(joinpath("docs", "REQUIRE")))); include(joinpath("docs", "make.jl"))'


### PR DESCRIPTION
strip on 1.0 returns a substring now (see https://github.com/JuliaLang/julia/pull/22496).
It wasn't ever very necessary anyway.

see https://github.com/GiovineItalia/Gadfly.jl/issues/1192#issuecomment-431198533