### PR TITLE
Update to Documenter 0.20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ test/master-output.html
 test/devel-output
 test/master-output
 test/diffed-output
+
+docs/Manifest.toml
 docs/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jobs:
         - |
           julia --color=yes --project=docs/ <<EOF
             using Pkg
+            Pkg.add(PackageSpec(name="Compose", rev="master"))
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()
             include("docs/make.jl")

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,18 @@ before_script:
   - julia -e 'using Pkg; Pkg.add(PackageSpec(name="Compose", rev="master"))'
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-  - julia -e 'using Pkg; foreach(x->Pkg.add(x), readlines(open(joinpath("docs", "REQUIRE")))); include(joinpath("docs", "make.jl"))'
+
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - |
+          julia --color=yes --project=docs/ <<EOF
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()
+            include("docs/make.jl")
+          EOF
+      after_success: skip

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ alt="Gadfly Logo" width="210"></img> </div>
 
 | **Documentation** | **Build Status** | **Help** |
 |:---:|:---:|:---:|
-| [![][docs-latest-img]][docs-latest-url] [![][docs-stable-img]][docs-stable-url] | [![][travis-img]][travis-url] [![][codecov-img]][codecov-url] | [![][slack-img]][slack-url] [![][gitter-img]][gitter-url] |
+| [![][docs-dev-img]][docs-dev-url] [![][docs-stable-img]][docs-stable-url] | [![][travis-img]][travis-url] [![][codecov-img]][codecov-url] | [![][slack-img]][slack-url] [![][gitter-img]][gitter-url] |
 
 **Gadfly** is a plotting and data visualization system written in
 [Julia](http://julialang.org/).
@@ -47,7 +47,7 @@ alt="Gadfly Gallery" width="1024"></img> </div>
 ## Documentation
 
 - [**STABLE**][docs-stable-url] &mdash; **most recently tagged version of the documentation.**
-- [**LATEST**][docs-latest-url] &mdash; *in-development version of the documentation.*
+- [**DEVEL**][docs-dev-url] &mdash; *in-development version of the documentation.*
 
 ## Contributing and Questions
 
@@ -59,8 +59,8 @@ valuable in helping us prioritize what to work on, so don't hesitate.
 If you have a question then you can ask for help in the plotting team of the
 [Julia Slack channel][slack-url] or the [Gitter chat room][gitter-url].
 
-[docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
-[docs-latest-url]: http://gadflyjl.org/latest
+[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
+[docs-dev-url]: http://gadflyjl.org/dev
 
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
 [docs-stable-url]: http://gadflyjl.org/stable

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,13 @@
+[deps]
+Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
+Showoff = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
+[compat]
+Documenter = "~0.20"

--- a/docs/REQUIRE
+++ b/docs/REQUIRE
@@ -1,9 +1,0 @@
-DataFrames
-Documenter
-Cairo
-RDatasets
-Compose
-Distributions
-Colors
-StatsBase
-Showoff

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,6 @@ using Documenter, Gadfly, Compose
 makedocs(
     modules = [Gadfly],
     clean = false,
-    format = :html,
     sitename = "Gadfly.jl",
     pages = Any[
         "Home" => "index.md",
@@ -41,8 +40,4 @@ makedocs(
 
 deploydocs(
     repo   = "github.com/GiovineItalia/Gadfly.jl.git",
-    osname = "linux",
-    deps = nothing,
-    make = nothing,
-    target = "build",
 )


### PR DESCRIPTION
Not sure if this will actually work.

Due to upcoming breaking changes in Documenter. This makes sure that the doc builds do not start failing when 0.20 lands in METADATA. [See this thread on Discourse for more information.](https://discourse.julialang.org/t/psa-documenter-jl-breaking-changes-version-capping/16431) 

Ref: JuliaDocs/Documenter.jl#861