### PR TITLE
Use -e option instead of heredoc in CI doc stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ jobs:
       os: linux
       script:
         - |
-          julia --color=yes --project=docs/ <<EOF
+          julia --color=yes --project=docs/ -e'
             using Pkg
             Pkg.add(PackageSpec(name="Compose", rev="master"))
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()
             include("docs/make.jl")
-          EOF
+          '
       after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ jobs:
     - stage: "Documentation"
       julia: 1.0
       os: linux
+      # disable global before_script in order not to install Compose twice
+      before_script:
       script:
         - |
           julia --color=yes --project=docs/ -e'


### PR DESCRIPTION
Follows up on #1217. I realized that the way I set up the Documentation build stage, it does not actually fail the stage if documentation building errors -- this fixes that. The problem is that Julia does not set the return code appropriately when the scripts are passed via stdin (e.g. as a heredoc, as was here; ref: JuliaLang/julia#30039).