### PR TITLE
Tweak mapping to improve plotting performance

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -165,10 +165,9 @@ plot(ls..., Guide.title("layer example"))
 """
 function layer(data_source,
                elements::ElementOrFunction...; mapping...)
-    mapping = Dict{Symbol, Any}(mapping)
     lyr = Layer()
     lyr.data_source = data_source
-    lyr.mapping = cleanmapping(mapping)
+    lyr.mapping = cleanmapping(Dict(mapping))
     if haskey(mapping, :order)
         lyr.order = mapping[:order]
     end
@@ -284,8 +283,7 @@ plot(my_matrix, x=Col.value(1), y=Col.value(2), Geom.line,
 """
 function plot(data_source,
               elements::ElementOrFunctionOrLayers...; mapping...)
-    mappingdict = Dict{Symbol, Any}(mapping)
-    return plot(data_source, mappingdict, elements...)
+    return plot(data_source, Dict(mapping), elements...)
 end
 
 """
@@ -304,8 +302,7 @@ plot(x=collect(1917:2018), y=1.02.^(0:101), Geom.line)
 ```
 """
 function plot(elements::ElementOrFunctionOrLayers...; mapping...)
-    mappingdict = Dict{Symbol, Any}(mapping)
-    plot(nothing, mappingdict, elements...)
+    plot(nothing, Dict(mapping), elements...)
 end
 
 """


### PR DESCRIPTION
This was a learning exercise for me to practice using Julia profiling tools. I picked Gadfly's plot function as it seemed likely to have some low hanging fruit while being relatively simple to grok. These changes improve the benchmark posted below on my system from 18.7 microseconds to 10.3 microseconds through minor refactoring; definitely not earth-shattering but in the direction of goodness. I leave it to the maintainers discretion whether it's worth their time to review this patch.

Note that this only improves plot generation and not plot display, which takes the bulk of the time in an interactive plotting session.

```julia

julia> using Gadfly, BenchmarkTools

julia> x = 1:10000; y = rand(1:100, 10000); c = rand(1:250, 10000);

julia> @btime plot(x=$x, y=$y, color=$c);
  10.281 μs (39 allocations: 4.44 KiB)
```

# Contributor checklist:

<!-- Make sure to complete all of these that apply -->

- [ ] I've updated the documentation to reflect these changes
- [ ] I've added an entry to `NEWS.md`
- [ ] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've `squash`'ed or `fixup`'ed junk commits with git-rebase
- [ ] I've built the docs and confirmed these changes don't cause new errors
-
-
-
