### PR TITLE
Stat.smooth() confidence bands

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 This is a log of major changes in Gadfly between releases. It is not exhaustive.
 Each release typically has a number of minor bug fixes beyond what is listed here.
 
+# Version 1.1.0
+ * `Stat.smooth(method=:lm)` confidence bands (#1231)
+
+
 # Version 0.9.0
  * conditionally depend on DataFrames (#1204)
  * `Geom.abline`: add support for nonlinear `Scale` transformations (#1201)

--- a/docs/src/gallery/statistics.md
+++ b/docs/src/gallery/statistics.md
@@ -46,6 +46,37 @@ p2 = plot(x=rand(Normal(), 100), y=Normal(), Stat.qq, Geom.point)
 hstack(p1,p2)
 ```
 
+## [`Stat.smooth`](@ref)
+
+```@example
+using Colors, Compose, Gadfly, RDatasets
+set_default_plot_size(21cm,8cm)
+salaries = dataset("car","Salaries")
+salaries.Salary /= 1000.0
+salaries.Discipline = ["Discipline $(x)" for x in salaries.Discipline]
+
+p = plot(salaries[salaries.Rank.=="Prof",:], x=:YrsService, y=:Salary, 
+    color=:Sex, xgroup = :Discipline,
+    Geom.subplot_grid(Geom.point,
+  layer(Stat.smooth(method=:lm, levels=[0.95, 0.99]), Geom.line, Geom.ribbon)), 
+    Scale.xgroup(levels=["Discipline A", "Discipline B"]),
+    Guide.colorkey(title="", pos=[0.43w, -0.4h]), 
+    Theme(point_size=2pt,
+        lowlight_color=c->RGBA{Float32}(c.r, c.g, c.b, 0.2) )
+)
+```
+
+```@example
+using DataFrames, Gadfly
+set_default_plot_size(14cm, 8cm)
+x = range(0.1, stop=4.9, length=30)
+D = DataFrame(x=x, y=x.+randn(length(x)))
+p = plot(D, x=:x, y=:y, Geom.point,
+  layer(Stat.smooth(method=:lm, levels=[0.90,0.99]), Geom.line, Geom.ribbon(fill=false)),
+     Theme(lowlight_color=c->"gray", line_style=[:solid, :dot])
+)
+```
+
 
 ## [`Stat.step`](@ref)
 

--- a/src/geom/ribbon.jl
+++ b/src/geom/ribbon.jl
@@ -1,9 +1,10 @@
 struct RibbonGeometry <: Gadfly.GeometryElement
     default_statistic::Gadfly.StatisticElement
+    fill::Bool
     tag::Symbol
 end
-RibbonGeometry(default_statistic=Gadfly.Stat.identity(); tag=empty_tag) =
-        RibbonGeometry(default_statistic, tag)
+RibbonGeometry(default_statistic=Gadfly.Stat.identity(); fill=true, tag=empty_tag) =
+        RibbonGeometry(default_statistic, fill, tag)
 
 """
     Geom.ribbon
@@ -15,7 +16,7 @@ const ribbon = RibbonGeometry
 
 default_statistic(geom::RibbonGeometry) = geom.default_statistic
 
-element_aesthetics(::RibbonGeometry) = [:x, :ymin, :ymax, :color]
+element_aesthetics(::RibbonGeometry) = [:x, :ymin, :ymax, :color, :linestyle]
 
 function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     Gadfly.assert_aesthetics_defined("Geom.ribbon", aes, :x, :ymin, :ymax)
@@ -23,56 +24,46 @@ function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
                                           element_aesthetics(geom)...)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.color = discretize_make_ia(RGB{Float32}[theme.default_color])
+    default_aes.linestyle = fill(1, length(aes.x))
+    default_aes.color = fill(theme.default_color, length(aes.x))
     aes = inherit(aes, default_aes)
 
-    aes_x, aes_ymin, aes_ymax = concretize(aes.x, aes.ymin, aes.ymax)
+    aes_x, aes_ymin, aes_ymax, aes_color, aes_linestyle = concretize(aes.x, aes.ymin, aes.ymax, aes.color, aes.linestyle)
+    XT, CT, LST = eltype(aes_x), eltype(aes_color), eltype(aes_linestyle)
+    YT = Float64
+    groups = collect((Tuple{CT, LST}), zip(aes_color, aes_linestyle))
+    ug = unique(groups)
+    
+    V = Vector{Tuple{XT, YT}}
+    K = Tuple{CT, LST}
 
-    if length(aes.color) == 1 &&
-        !(isa(aes.color, IndirectArray) && length(filter(!ismissing, aes.color.values)) > 1)
-        max_points = collect(zip(aes_x, aes_ymax))
-        sort!(max_points, by=first)
-
-        min_points = collect(zip(aes_x, aes_ymin))
-        sort!(min_points, by=first, rev=true)
-
-        ctx = compose!(
-            context(),
-            Compose.polygon([collect(Iterators.flatten((min_points, max_points)))]),
-            fill(theme.lowlight_color(aes.color[1])))
-    else
-        XT, YT = eltype(aes_x), promote_type(eltype(aes_ymin), eltype(aes_ymax))
-        max_points = Dict{RGB{Float32}, Vector{(Tuple{XT, YT})}}()
-        for (x, y, c) in zip(aes_x, aes_ymax, aes.color)
-            if !haskey(max_points, c)
-                max_points[c] = Array{Tuple{XT, YT}}(undef, 0)
-            end
-            push!(max_points[c], (x, y))
-        end
-
-        min_points = Dict{RGB{Float32}, Vector{(Tuple{XT, YT})}}()
-        for (x, y, c) in zip(aes.x, aes.ymin, aes.color)
-            if !haskey(min_points, c)
-                min_points[c] = Array{Tuple{XT, YT}}(undef, 0)
-            end
-            push!(min_points[c], (x, y))
-        end
-
-        for c in keys(max_points)
-            sort!(max_points[c], by=first)
-            sort!(min_points[c], by=first, rev=true)
-        end
-
-        ctx = compose!(
-            context(),
-            Compose.polygon([collect((Tuple{XT, YT}), Iterators.flatten((min_points[c], max_points[c])))
-                     for c in keys(max_points)], geom.tag),
-            fill([theme.lowlight_color(c) for c in keys(max_points)]))
+    max_points = Dict{K, V}(g=>V[] for g in ug)
+    for (x, y, c, ls) in zip(aes_x, aes_ymax, aes_color, aes_linestyle)
+        push!(max_points[(c,ls)], (x, y))
     end
+
+    min_points = Dict{K, V}(g=>V[] for g in ug)
+    for (x, y, c, ls) in zip(aes_x, aes_ymin, aes_color, aes_linestyle)
+        push!(min_points[(c,ls)], (x, y))
+    end
+
+    for k in keys(max_points)
+        sort!(max_points[k], by=first)
+        sort!(min_points[k], by=first, rev=true)
+    end
+
+    kys = keys(max_points)
+    polys = [collect(Tuple{XT, YT}, Iterators.flatten((min_points[k], max_points[k]))) for k in kys]
+    lines = [collect(Tuple{XT, YT}, Iterators.flatten((min_points[k], [(last(min_points[k])[1], NaN)], max_points[k]))) for k in kys]
+
+    colors = [theme.lowlight_color(c) for (c,ls) in kys]
+    linestyles = [Gadfly.get_stroke_vector(theme.line_style[ls]) for (c,ls) in kys]
+
+    ctx = geom.fill ? compose!(context(), Compose.polygon(polys, geom.tag), fill(colors)) : 
+        compose!(context(), Compose.line(lines, geom.tag), fill(nothing), stroke(colors), strokedash(linestyles))
 
     return compose!(
         ctx,
         svgclass("geometry"),
-        stroke(nothing),
         linewidth(theme.line_width))
 end

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -32,9 +32,9 @@ function concretize(xss::AbstractVector...)
         @label next_j1
     end
 
-    yss = Array{AbstractVector}(length(xss))
+    yss = Vector{AbstractVector}(undef, length(xss))
     for (i, xs) in enumerate(xss)
-        yss[i] = Array{eltype(xs)}(count)
+        yss[i] = Vector{eltype(xs)}(undef, count)
     end
 
     k = 1

--- a/test/testscripts/nan_skipping.jl
+++ b/test/testscripts/nan_skipping.jl
@@ -4,4 +4,4 @@ set_default_plot_size(6inch, 3inch)
 
 x = [1, 2, 3, 4, 5]
 y = [1.0, 2.0, NaN, 4.0, 5.0]
-plot(x=x, y=y, Geom.line, Geom.point)
+plot(x=x, y=y, ymin=y.-0.5, ymax=y.+0.5, Geom.line, Geom.point, Geom.ribbon)

--- a/test/testscripts/stat_smooth.jl
+++ b/test/testscripts/stat_smooth.jl
@@ -1,0 +1,10 @@
+using Colors, Gadfly, RDatasets
+
+set_default_plot_size(5inch,4inch)
+iris = dataset("datasets","iris")
+
+p = plot(iris, x=:SepalLength, y=:PetalLength, color=:Species, Geom.point,
+     layer(Stat.smooth(method=:lm, levels=[0.90, 0.99]), Geom.line, Geom.ribbon), 
+    Theme(lowlight_color=c->RGBA{Float32}(c.r, c.g, c.b, 0.2),
+        key_position=:inside)
+)


### PR DESCRIPTION

- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR:
- Adds confidence bands for `Stat.smooth(method=:lm)` 
    (but not for `method=:loess`, because currently Loess.jl doesn't return the loess standard error #519)
- Updates `Geom.ribbon` (fixes #1167, closes #559)
- Adds gallery examples for `Stat.smooth()`

### Examples
```julia
salaries = dataset("car","Salaries")
salaries.Salary /= 1000.0
salaries.Discipline = ["Discipline $(x)" for x in salaries.Discipline] 

p = plot(salaries[salaries.Rank.=="Prof",:], x=:YrsService, y=:Salary, 
    color=:Sex, xgroup = :Discipline,
    Geom.subplot_grid(Geom.point,
     layer(Stat.smooth(method=:lm, levels=[0.95, 0.99]), Geom.line, Geom.ribbon)), 
    Scale.xgroup(levels=["Discipline A", "Discipline B"]),
    Guide.colorkey(title="", pos=[0.43w, -0.4h]), 
    Theme(point_size=2pt,
        lowlight_color=c->RGBA{Float32}(c.r, c.g, c.b, 0.2) )
)
```
![stat_smooth1](https://user-images.githubusercontent.com/18226881/50516758-c4225280-0b00-11e9-88bf-873c891cf0a2.png)



```julia
x = range(0.1, stop=4.9, length=30)
D = DataFrame(x=x, y=x.+randn(length(x)))

p = plot(D, x=:x, y=:y, Geom.point,
     layer(Stat.smooth(method=:lm, levels=[0.90,0.99]), Geom.line, Geom.ribbon(fill=false)),
     Theme(lowlight_color=c->"gray", line_style=[:solid, :dot])
)
```
![stat_smooth2](https://user-images.githubusercontent.com/18226881/50516789-eddb7980-0b00-11e9-93c0-8b3fa2c536a9.png)
