### PR TITLE
support TerminalExtensions.jl

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -41,6 +41,11 @@ export Plot, Layer, Theme, Col, Row, Scale, Coord, Geom, Guide, Stat, Shape, ren
 export SVGJS, SVG, PGF, PNG, PS, PDF, draw, inch, mm, cm, px, pt, color, @colorant_str, vstack, hstack, title, gridstack
 
 
+function link_terminalextensions()
+    @debug "Loading TerminalExtensions support into Gadfly"
+    include("terminalextensions.jl")
+end
+
 function __init__()
     # Define an XML namespace for custom attributes
     Compose.xmlns["gadfly"] = "http://www.gadflyjl.org/ns"
@@ -58,6 +63,7 @@ function __init__()
     pushdisplay(GadflyDisplay())
 
     @require DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0" link_dataframes()
+    @require TerminalExtensions="d3a6a179-465e-5219-bd3e-0137f7fd17c7" link_terminalextensions()
 end
 
 

--- a/src/mapping.jl
+++ b/src/mapping.jl
@@ -238,6 +238,6 @@ function evalmapping!(mapping::Dict, data_source, data::Data)
 end
 
 function link_dataframes()
-    @info "Loading DataFrames support into Gadfly.jl"
+    @debug "Loading DataFrames support into Gadfly"
     include("dataframes.jl")
 end

--- a/src/terminalextensions.jl
+++ b/src/terminalextensions.jl
@@ -1,0 +1,17 @@
+using .TerminalExtensions
+
+function putatend(idisplay, display::iTerm2.InlineDisplay)
+  iterm2display = splice!(Base.Multimedia.displays, idisplay)
+  push!(Base.Multimedia.displays, iterm2display)
+  true
+end
+putatend(idisplay, display) = false
+
+for (idisplay, display) in enumerate(Base.Multimedia.displays)
+  putatend(idisplay, display) && break
+end
+
+function display(d::iTerm2.InlineDisplay, p::Union{Plot,Compose.Context})
+    draw(PNG(), p)
+    print("\r")
+end


### PR DESCRIPTION
<!-- Replace XXX with the issue number that this PR fixes, remove if there is no corresponding issue -->
Fixes #1230 @montyvesselinov

ideally it would be nice to replace the `popdisplay(GadflyDisplay)` in src/terminalextensions.jl with code to put `GadflyDisplay` before `iTerm2.InlineDisplay`.  as a fallback in case you have TerminalExtensions in your startup.jl, but are using a terminal which is not supported.  one can get a `typeof(Base.Multimedia.displays[i])`, but how does one tell which module that type was defined in?

