### PR TITLE
Fixes #1218

### DIFF
--- a/docs/src/gallery/statistics.md
+++ b/docs/src/gallery/statistics.md
@@ -12,6 +12,23 @@ p2 = plot(dataset("datasets", "iris"), x="SepalLength", y="SepalWidth",
 hstack(p1,p2)
 ```
 
+## [`Stat.contour`](@ref)
+
+```@example
+using DataFrames, Gadfly
+set_default_plot_size(21cm, 8cm)
+expand_grid(xv, yv, n::Int) = vcat([[x y z] for x in xv, y in yv, z in 1:n]...)
+a = expand_grid(6.0:10, 1.0:4, 3)
+D= DataFrame(x= a[:,1], y=a[:,2], z=a[:,3].*a[:,1].*a[:,2], 
+    level=string.("L",floor.(Int, a[:,3])) )
+coord = Coord.cartesian(xmin=6, xmax=10, ymin=1, ymax=4)
+
+plot(D, xgroup=:level, x=:x, y=:y, color=:z,
+    Geom.subplot_grid(coord, layer(z=:z, Stat.contour(levels=7), Geom.line)),
+    Scale.color_continuous(minvalue=0, maxvalue=120)
+)
+```
+
 ## [`Stat.density`](@ref)
 
 ```@example

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -409,6 +409,7 @@ function render_prepare(plot::Plot)
     for (layer, layer_data) in zip(plot.layers, datas)
         if isa(layer.geom, Geom.SubplotGeometry)
             for subplot_layer in layers(layer.geom)
+                isa(default_statistic(subplot_layer.geom), Stat.ContourStatistic) &&  @warn "For subplots, use `Stat.contour()` and `Geom.line`, instead of `Geom.contour()`"
                 subplot_data = Data()
                 if subplot_layer.data_source === nothing
                     subplot_layer.data_source = layer.data_source
@@ -679,11 +680,9 @@ function render_prepare(plot::Plot)
 
 
     # IIa. Layer-wise statistics
-    if !facet_plot
         for (stats, aes) in zip(layer_stats, layer_aess)
             Stat.apply_statistics(stats, scales, coord, aes)
         end
-    end
 
     # IIb. Plot-wise Statistics
     plot_aes = concat(layer_aess...)

--- a/test/testscripts/contour_dataframe.jl
+++ b/test/testscripts/contour_dataframe.jl
@@ -5,10 +5,10 @@ expand_grid(xv, yv, n::Int) = vcat([[x y z] for x in xv, y in yv, z in 1:n]...)
 
 a = expand_grid(6.0:10, 1.0:4, 3)
 
-D= DataFrame(x= a[:,1], y=a[:,2], z=a[:,3].*a[:,1].*a[:,2], g = string.(floor.(Int, a[:,3])) )
+D= DataFrame(x=a[:,1], y=a[:,2], z=a[:,3].*a[:,1].*a[:,2], g=string.(floor.(Int, a[:,3])) )
 coord = Coord.cartesian(xmin=6, xmax=10, ymin=1, ymax=4)
 
 plot(D, xgroup=:g, x=:x, y=:y, color=:z,
-    Geom.subplot_grid(coord, layer(z=:z, Geom.contour(levels=7))),
+    Geom.subplot_grid(coord, layer(z=:z, Stat.contour(levels=7), Geom.line)),
     Scale.color_continuous(minvalue=0, maxvalue=120)
 )

--- a/test/testscripts/subplot_grid_hexbin.jl
+++ b/test/testscripts/subplot_grid_hexbin.jl
@@ -1,0 +1,11 @@
+using Gadfly, RDatasets
+set_default_plot_size(6.6inch, 3.3inch)
+
+salaries = dataset("car","Salaries")
+salaries.Salary /= 1000.0
+salaries.Discipline = ["Discipline $(x)" for x in salaries.Discipline]
+
+plot(salaries[salaries.Rank.=="Prof",:], x=:YrsService, y=:Salary, xgroup=:Discipline,
+    Geom.subplot_grid(Geom.hexbin(xbincount=20, ybincount=20)),
+    Scale.xgroup(levels=["Discipline A", "Discipline B"])
+)


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR:

- Fixes #1218
- `Geom.subplot_grid(Geom.contour())` also doesn't behave in the same way as for Julia 0.6. This PR fixes this issue by instead using: `Geom.subplot_grid(layer(Stat.contour, Geom.line))`,
and throws a warning if a user tries `Geom.subplot_grid(Geom.contour())`
- Adds `Stat.contour` example in the plot gallery 

### Example #1218
```julia
using DataFrames, Distributions, StatsBase
N = 1000
df1 = DataFrame(
  x1 = rand(Normal(1,3), N),
  x2 = sample(["High", "Medium", "Low"], pweights([0.25,0.45,0.30]), N),
  x3 = rand(Normal(2, 6), N)
)

p = plot(df1, xgroup =:x2,  x=:x1,  y=:x3,
    Geom.subplot_grid(Geom.hexbin(xbincount=20, ybincount=20)),
    Guide.xlabel(nothing)
)
```
![issue1218](https://user-images.githubusercontent.com/18226881/50735064-91f9aa80-11fc-11e9-929e-42eeb3890781.png)
