### PR TITLE
Stat.dodge

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ This is a log of major changes in Gadfly between releases. It is not exhaustive.
 Each release typically has a number of minor bug fixes beyond what is listed here.
 
 # Version 1.1.0
+ * Add `Stat.dodge` (#1240) 
  * `Stat.smooth(method=:lm)` confidence bands (#1231)
 
 

--- a/docs/src/gallery/statistics.md
+++ b/docs/src/gallery/statistics.md
@@ -35,6 +35,33 @@ p2 = plot(vcat(Db...), x=:x, color=:u,
 hstack(p1,p2)
 ```
 
+## [`Stat.dodge`](@ref)
+
+```@example
+using DataFrames, Gadfly, RDatasets, Statistics
+set_default_plot_size(21cm, 8cm)
+salaries = dataset("car","Salaries")
+salaries.Salary /= 1000.0
+salaries.Discipline = ["Discipline $(x)" for x in salaries.Discipline]
+df = by(salaries, [:Rank,:Discipline], :Salary=>mean, :Salary=>std)
+[df[i] = df.Salary_mean.+j*df.Salary_std for (i,j) in zip([:ymin, :ymax], [-1, 1.0])]
+df[:label] = string.(round.(Int, df.Salary_mean))
+
+p1 = plot(df, x=:Discipline, y=:Salary_mean, color=:Rank, 
+    Scale.x_discrete(levels=["Discipline A", "Discipline B"]),
+    label=:label, Geom.label(position=:centered), Stat.dodge(position=:stack),
+    Geom.bar(position=:stack)
+)
+p2 = plot(df, y=:Discipline, x=:Salary_mean, color=:Rank, 
+    Coord.cartesian(yflip=true), Scale.y_discrete,
+    label=:label, Geom.label(position=:right), Stat.dodge(axis=:y),
+    Geom.bar(position=:dodge, orientation=:horizontal), 
+    Scale.color_discrete(levels=["Prof", "AssocProf", "AsstProf"]),
+    Guide.yticks(orientation=:vertical), Guide.ylabel(nothing)
+)
+hstack(p1, p2)
+```
+
 ## [`Stat.qq`](@ref)
 
 ```@example

--- a/src/geom/bar.jl
+++ b/src/geom/bar.jl
@@ -21,7 +21,7 @@ Draw bars of height `y` centered at positions `x`, or from `xmin` to `xmax`.
 If orientation is `:horizontal` switch x for y.  Optionally categorically
 groups bars using the `color` aesthetic.  If `position` is `:stack` they will
 be placed on top of each other;  if it is `:dodge` they will be placed side by
-side.
+side.  For labelling dodged or stacked bar plots see [`Stat.dodge`](@ref).
 """
 const bar = BarGeometry
 
@@ -170,7 +170,7 @@ function render_dodged_bar(geom::BarGeometry,
                                     orientation::Symbol)
     # preserve factor orders of pooled data arrays
     if isa(aes.color, IndirectArray)
-        idxs = sortperm(aes.color.index, rev=true)
+        idxs = sortperm(aes.color.index, rev=false)
     else
         idxs = 1:length(aes.color)
     end

--- a/src/geom/errorbar.jl
+++ b/src/geom/errorbar.jl
@@ -1,7 +1,9 @@
 struct ErrorBarGeometry <: Gadfly.GeometryElement
+    default_statistic::Gadfly.StatisticElement
     tag::Symbol
 end
-ErrorBarGeometry(; tag=empty_tag) = ErrorBarGeometry(tag)
+ErrorBarGeometry(default_statistic=Gadfly.Stat.identity(); tag=empty_tag) = 
+    ErrorBarGeometry(default_statistic, tag)
 
 
 struct XErrorBarGeometry <: Gadfly.GeometryElement
@@ -42,9 +44,14 @@ color them with `color`.
 """
 const yerrorbar = YErrorBarGeometry
 
-element_aesthetics(::ErrorBarGeometry) = [:x, :y, :xmin, :xmax, :ymin, :ymax]
-element_aesthetics(::XErrorBarGeometry) = [:y, :xmin, :xmax]
-element_aesthetics(::YErrorBarGeometry) = [:x, :ymin, :ymax]
+
+
+
+element_aesthetics(::ErrorBarGeometry) = [:x, :y, :xmin, :xmax, :ymin, :ymax, :color]
+element_aesthetics(::XErrorBarGeometry) = [:y, :xmin, :xmax, :color]
+element_aesthetics(::YErrorBarGeometry) = [:x, :ymin, :ymax, :color]
+default_statistic(geom::ErrorBarGeometry) = geom.default_statistic
+
 
 # Generate a form for the errorbar geometry.
 #
@@ -58,12 +65,12 @@ element_aesthetics(::YErrorBarGeometry) = [:x, :ymin, :ymax]
 #
 function render(geom::ErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     # check for X and Y error bar aesthetics
-    if isempty(Gadfly.undefined_aesthetics(aes, element_aesthetics(xerrorbar())...))
+    if isempty(Gadfly.undefined_aesthetics(aes, :y, :xmin, :xmax))
         xctx = render(xerrorbar(), theme, aes)
     else
         xctx = nothing
     end
-    if isempty(Gadfly.undefined_aesthetics(aes, element_aesthetics(yerrorbar())...))
+    if isempty(Gadfly.undefined_aesthetics(aes, :x, :ymin, :ymax))
         yctx = render(yerrorbar(), theme, aes)
     else
         yctx = nothing
@@ -72,10 +79,8 @@ function render(geom::ErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthet
 end
 
 function render(geom::YErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
-    Gadfly.assert_aesthetics_defined("Geom.errorbar", aes,
-                                     element_aesthetics(geom)...)
-    Gadfly.assert_aesthetics_equal_length("Geom.errorbar", aes,
-                                          element_aesthetics(geom)...)
+    Gadfly.assert_aesthetics_defined("Geom.errorbar", aes, :x, :ymin, :ymax)
+    Gadfly.assert_aesthetics_equal_length("Geom.errorbar", aes, :x, :ymin, :ymax)
 
     default_aes = Gadfly.Aesthetics()
     default_aes.color = discretize_make_ia(RGB{Float32}[theme.default_color])
@@ -112,10 +117,8 @@ function render(geom::YErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthe
 end
 
 function render(geom::XErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
-    Gadfly.assert_aesthetics_defined("Geom.errorbar", aes,
-                                     element_aesthetics(geom)...)
-    Gadfly.assert_aesthetics_equal_length("Geom.errorbar", aes,
-                                          element_aesthetics(geom)...)
+    Gadfly.assert_aesthetics_defined("Geom.errorbar", aes, :y, :xmin, :xmax)
+    Gadfly.assert_aesthetics_equal_length("Geom.errorbar", aes, :y, :xmin, :xmax)
 
     default_aes = Gadfly.Aesthetics()
     default_aes.color = discretize_make_ia(RGB{Float32}[theme.default_color])

--- a/test/testscripts/stat_dodge.jl
+++ b/test/testscripts/stat_dodge.jl
@@ -1,0 +1,25 @@
+using Compose, DataFrames, Gadfly, RDatasets, Statistics
+set_default_plot_size(21cm, 8cm)
+
+salaries = dataset("car","Salaries")
+salaries.Salary /= 1000.0
+salaries.Discipline = ["Discipline $(x)" for x in salaries.Discipline]
+df = by(salaries, [:Rank,:Discipline], :Salary=>mean, :Salary=>std)
+[df[i] = df.Salary_mean.+j*df.Salary_std for (i,j) in zip([:ymin, :ymax], [-1, 1.0])]
+df[:label] = string.(round.(Int, df.Salary_mean))
+
+p1 = plot(df, x=:Discipline, y=:Salary_mean, color=:Rank, 
+    Scale.x_discrete(levels=["Discipline A", "Discipline B"]),
+    ymin=:ymin, ymax=:ymax, Geom.errorbar, Stat.dodge,
+    Geom.bar(position=:dodge), 
+    Scale.color_discrete(levels=["Prof", "AssocProf", "AsstProf"]),
+    Guide.colorkey(title="", pos=[0.76w, -0.38h]),
+    Theme(bar_spacing=0mm, stroke_color=c->"black")
+)
+p2 = plot(df, x=:Salary_mean, y=:Discipline, color=:Rank, 
+    Scale.y_discrete(levels=["Discipline A", "Discipline B"]),
+    label=:label, Geom.label(position=:centered), Stat.dodge(position=:stack, axis=:y),
+    Geom.bar(position=:stack, orientation=:horizontal),
+    Guide.yticks(orientation=:vertical), Guide.ylabel(nothing)
+)
+hstack(p1, p2)


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR:
- Adds `Stat.dodge(position= , axis= )` which allows geometries, e.g. labels & errorbars, to be dodged/stacked
- ~~Adds Geom.barerror(position= , axis= ) = Stat.dodge(position, axis) + Geom.errorbar~~
- has defaults `Stat.dodge(position=:dodge, axis=:x)`
- closes #525, closes #588, closes #733
- Also closes GiovineItalia/Compose.jl#206

### Examples
Examples of dodged bar plots with errors and labels:
```julia
using Compose, DataFrames, RDatasets, Statistics
salaries = dataset("car","Salaries")
salaries.Salary /= 1000.0
salaries.Discipline = ["Discipline $(x)" for x in salaries.Discipline]
df = by(salaries, [:Rank,:Discipline], :Salary=>mean, :Salary=>std)
[df[i] = df.Salary_mean.+j*df.Salary_std for (i,j) in zip([:ymin, :ymax], [-1, 1.0])]
df[:label] = string.(round.(Int, df.Salary_mean))

p1 = plot(df, x=:Discipline, y=:Salary_mean, color=:Rank, 
    Scale.x_discrete(levels=["Discipline A", "Discipline B"]),
    ymin=:ymin, ymax=:ymax, Geom.errorbar, Stat.dodge,
    Geom.bar(position=:dodge), 
    Scale.color_discrete(levels=["Prof", "AssocProf", "AsstProf"]),
    Guide.colorkey(title="", pos=[0.76w, -0.38h]),
    Theme(bar_spacing=0mm, stroke_color=c->"black")
)
p2 = plot(df, y=:Discipline, x=:Salary_mean, color=:Rank, 
    Coord.cartesian(yflip=true), Scale.y_discrete,
    label=:label, Geom.label(position=:right), Stat.dodge(axis=:y),
    Geom.bar(position=:dodge, orientation=:horizontal), 
    Scale.color_discrete(levels=["Prof", "AssocProf", "AsstProf"]),
    Guide.yticks(orientation=:vertical), Guide.ylabel(nothing)
)
hstack(p1,p2)
```
![dodge1](https://user-images.githubusercontent.com/18226881/50814109-a957a580-136c-11e9-8486-e245951bb6bb.png)
Here's an example of a stacked bar plot with labels:
```julia
p3 = plot(df, x=:Discipline, y=:Salary_mean, color=:Rank, 
    Scale.x_discrete(levels=["Discipline A", "Discipline B"]),
    label=:label, Geom.label(position=:centered), Stat.dodge(position=:stack),
    Geom.bar(position=:stack)
)
```
![dodge2](https://user-images.githubusercontent.com/18226881/50814216-05bac500-136d-11e9-8d56-768dbffb5ba3.png)


