### PR TITLE
Boxplot dodging

### DIFF
--- a/docs/src/gallery/geometries.md
+++ b/docs/src/gallery/geometries.md
@@ -63,9 +63,19 @@ plot(dataset("lattice", "singer"), x="VoicePart", y="Height", Geom.beeswarm)
 ## [`Geom.boxplot`](@ref)
 
 ```@example
-using Gadfly, RDatasets
-set_default_plot_size(14cm, 8cm)
-plot(dataset("lattice", "singer"), x="VoicePart", y="Height", Geom.boxplot)
+using Compose, Gadfly, RDatasets
+set_default_plot_size(21cm, 8cm)
+singers, salaries = dataset("lattice", "singer"), dataset("car","Salaries")
+salaries.Salary /= 1000.0
+salaries.Discipline = ["Discipline $(x)" for x in salaries.Discipline]
+p1 = plot(singers, x=:VoicePart, y=:Height, Geom.boxplot, 
+    Theme(default_color="MidnightBlue"))
+p2 = plot(salaries, x=:Discipline, y=:Salary, color=:Rank,
+    Scale.x_discrete(levels=["Discipline A", "Discipline B"]),
+    Geom.boxplot, Theme(boxplot_spacing=0.1cx),
+    Guide.colorkey(title="", pos=[0.78w,-0.4h])
+)
+hstack(p1, p2)
 ```
 
 

--- a/src/geom/boxplot.jl
+++ b/src/geom/boxplot.jl
@@ -17,6 +17,8 @@ outliers.
 
 Alternatively, if the `y` aesthetic is specified instead, the middle, hinges,
 fences, and outliers aesthetics will be computed using [`Stat.boxplot`](@ref).
+
+Boxplots will be automatically dodged by specifying a `color` aesthetic different to the `x` aesthetic.
 """
 const boxplot = BoxplotGeometry
 
@@ -125,11 +127,9 @@ function render(geom::BoxplotGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
         xys = collect(Iterators.flatten(zip(cycle([x]), ys, cycle([c]))
                              for (x, ys, c) in zip(xs, aes.outliers, cs)))
         compose!(ctx, (context(),
-            (context(), Shape.circle([x for (x, y, c) in xys],
-                    [y for (x, y, c) in xys],
-                    [theme.point_size], to), svgclass("marker")),
+            Shape.circle([x for (x, y, c) in xys], [y for (x, y, c) in xys], [theme.point_size], to), svgclass("marker"),
              stroke([theme.discrete_highlight_color(c) for (x, y, c) in xys]),
-             fill([c for (x, y, c) in xys])))
+             fill([c for (x, y, c) in xys]) ))
     end
 
     # Middle

--- a/test/testscripts/colored_boxplot.jl
+++ b/test/testscripts/colored_boxplot.jl
@@ -1,6 +1,12 @@
-using Gadfly, RDatasets
+using Compose, Gadfly, RDatasets
 
-set_default_plot_size(6inch, 3inch)
+set_default_plot_size(21cm, 16cm)
 
 mpg = dataset("ggplot2","mpg")
-plot(mpg, x=:Class, y=:Hwy, Geom.boxplot, color=:Class)
+p1 = plot(mpg, x=:Class, y=:Hwy, color=:Class, Geom.boxplot, Theme(boxplot_spacing=0.3cx) )
+
+p2 = plot(mpg, x=:Class, y=:Hwy, color=:Drv, Geom.boxplot,
+    Guide.colorkey(labels=["front", "4-wheel\t\t","rear"]),
+    Theme(boxplot_spacing=0.1cx) )
+
+vstack(p1, p2)


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR:
- adds dodged boxplots, if aesthetic `color` is different to aesthetic `x`
- closes #482
- fixed png color issues in `Geom.boxplot` outliers (see GiovineItalia/Compose.jl#339)

### Example
```
using Compose, Gadfly, RDatasets
mpg = dataset("ggplot2","mpg")
p1 = plot(mpg, x=:Class, y=:Hwy, color=:Class, Geom.boxplot, Theme(boxplot_spacing=0.3cx) )
p2 = plot(mpg, x=:Class, y=:Hwy, color=:Drv, Geom.boxplot,
    Guide.colorkey(labels=["front", "4-wheel\t\t","rear"]),
    Theme(boxplot_spacing=0.1cx) )
vstack(p1, p2)
```
![boxplot](https://user-images.githubusercontent.com/18226881/52015372-f4ad4000-2535-11e9-8ac1-ee7c0d4c28d4.png)

