### PR TITLE
Stat.histogram(limits=())

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ This is a log of major changes in Gadfly between releases. It is not exhaustive.
 Each release typically has a number of minor bug fixes beyond what is listed here.
 
 # Version 1.1.0
+ * Add `limits=(min= , max= )` to `Stat.histogram` (#1249)
+ * Add dodged boxplots (#1246)
  * Add `Stat.dodge` (#1240) 
  * `Stat.smooth(method=:lm)` confidence bands (#1231)
 

--- a/docs/src/gallery/geometries.md
+++ b/docs/src/gallery/geometries.md
@@ -244,13 +244,18 @@ hstack(p1,p2)
 ## [`Geom.histogram`](@ref)
 
 ```@example
-using Gadfly, RDatasets
+using Distributions, Gadfly, RDatasets
 set_default_plot_size(21cm, 16cm)
 D = dataset("ggplot2","diamonds")
+gamma = Gamma(2, 2)
+Dgamma = DataFrame(x=rand(gamma, 10^4))
 p1 = plot(D, x="Price", Geom.histogram)
 p2 = plot(D, x="Price", color="Cut", Geom.histogram)
 p3 = plot(D, x="Price", color="Cut", Geom.histogram(bincount=30))
-p4 = plot(D, x="Price", color="Cut", Geom.histogram(bincount=30, density=true))
+p4 = plot(Dgamma, Coord.cartesian(xmin=0, xmax=20),
+    layer(x->pdf(gamma, x), 0, 20, Geom.line, Theme(default_color="black")),
+    layer(x=:x, Geom.histogram(bincount=20, density=true, limits=(min=0,))),
+    Theme(default_color="bisque") )
 gridstack([p1 p2; p3 p4])
 ```
 

--- a/src/geom/bar.jl
+++ b/src/geom/bar.jl
@@ -27,7 +27,7 @@ const bar = BarGeometry
 
 """
     Geom.histogram[(; position=:stack, bincount=nothing, minbincount=3, maxbincount=150,
-                    orientation=:vertical, density=false)]
+                    orientation=:vertical, density=false, limits=NamedTuple())]
 
 Draw histograms from a series of observations in `x` or `y` optionally grouping
 by `color`.  This geometry is equivalent to [`Geom.bar`](@ref) with
@@ -36,7 +36,7 @@ by `color`.  This geometry is equivalent to [`Geom.bar`](@ref) with
 histogram(; position=:stack, bincount=nothing,
             minbincount=3, maxbincount=150,
             orientation::Symbol=:vertical,
-            density::Bool=false,
+            density::Bool=false, limits::NamedTuple=NamedTuple(),
             tag::Symbol=empty_tag) =
     BarGeometry(position, orientation,
                 Gadfly.Stat.histogram(bincount=bincount,
@@ -44,7 +44,7 @@ histogram(; position=:stack, bincount=nothing,
                                       maxbincount=maxbincount,
                                       position=position,
                                       orientation=orientation,
-                                      density=density),
+                                      density=density, limits=limits),
                 tag)
 
 # Render a single color bar chart

--- a/test/testscripts/histogram_limits.jl
+++ b/test/testscripts/histogram_limits.jl
@@ -1,0 +1,15 @@
+using DataFrames, Distributions, Gadfly
+
+set_default_plot_size(6inch, 3inch)
+
+beta = Beta(2,2)
+Dbeta = DataFrame(x=rand(beta, 10^4))
+layer1 = layer(x->pdf(beta, x), 0, 1, Geom.line, Theme(default_color="black"))
+p1 = plot(Dbeta, layer1,
+    layer(x=:x, Geom.histogram(bincount=20, density=true, limits=(min=0,))),
+)
+p2 = plot(Dbeta, layer1,
+    layer(x=:x, Geom.histogram(bincount=20, density=true, limits=(min=0, max=1)))
+)
+
+hstack(p1, p2)


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors


### This PR

- Add `limits=(min= , max=)` to `Stat.histogram` (and `Geom.histogram`)
- closes #347

### Example

```julia
using DataFrames, Distributions
gamma, beta = Gamma(2,2), Beta(2,2)
D = DataFrame(x1=rand(gamma, 10^4), x2=rand(beta,10^4))
layerf(dist, max) = layer(x->pdf(dist, x), 0, max, Geom.line, Theme(default_color="black"))

p1 = plot(D,  Coord.cartesian(xmin=0, xmax=20), layerf(gamma, 20),
    layer(x=:x1, Geom.histogram(bincount=20, density=true, limits=(min=0,))) )
p2 = plot(D, layerf(beta, 1),
    layer(x=:x2, Geom.histogram(bincount=20, density=true, limits=(min=0,max=1))) )

hstack(p1, p2)
```
![hist_limits](https://user-images.githubusercontent.com/18226881/52274809-e29e2800-29a1-11e9-8d02-30abb12c1ad4.png)
