### PR TITLE
Scale.color_continuous limits

### DIFF
--- a/src/color_misc.jl
+++ b/src/color_misc.jl
@@ -50,11 +50,16 @@ end
 
 # Continuous scales
 
-# Generate a gradient between n >= 2, colors.
 
-# Then functions return functions suitable for ContinuousColorScales.
 """
     function lab_gradient(cs::Color...)
+
+Generate a function `f(p)` that creates a gradient between n≥2 colors, where `0≤p≤1`.
+If you have a collection of colors, then use the splatting operator `...`:
+```julia
+f = Scale.lab_gradient(range(HSV(0,1,1), stop=HSV(250,1,1), length=100)...)
+```
+Function `f` can be used like so: `Scale.color_continuous(colormap=f)`.
 """
 function lab_gradient(cs::Color...)
     length(cs) < 2 && error("Two or more colors are needed for gradients")
@@ -69,6 +74,12 @@ function lab_gradient(cs::Color...)
     end
     f
 end
+
+"""
+    function lab_gradient(cs...)
+
+Can be applied to other types, e.g. `Scale.lab_gradient("blue","ghostwhite","red")`
+"""
 lab_gradient(cs...) = lab_gradient(Gadfly.parse_colorant(cs)...)
 
 """

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -572,7 +572,7 @@ Create a continuous color scale by mapping
 $(aes2str(element_aesthetics(color_continuous()))) to a `Color`.  `minvalue`
 and `maxvalue` specify the data values corresponding to the bottom and top of
 the color scale.  `colormap` is a function defined on the interval from 0 to 1
-that returns a `Color`.
+that returns a `Color`. See also [`lab_gradient`](@ref).
 
 Either input `Stat.color_continuous` as an argument to `plot`, or
 set `continuous_color_scale` in a [Theme](@ref Themes).
@@ -607,23 +607,18 @@ function apply_scale(scale::ContinuousColorScale,
         return
     end
 
-    if scale.minvalue != nothing
-        cmin = scale.minvalue
-    end
-
-    if scale.maxvalue  != nothing
-        cmax = scale.maxvalue
-    end
+    strict_span = false
+    scale.minvalue != nothing && scale.maxvalue != nothing && (strict_span=true)
+    scale.minvalue != nothing && (cmin=scale.minvalue)
+    scale.maxvalue != nothing && (cmax=scale.maxvalue)
 
     cmin, cmax = promote(cmin, cmax)
 
     cmin = scale.trans.f(cmin)
     cmax = scale.trans.f(cmax)
 
-    ticks, viewmin, viewmax = Gadfly.optimize_ticks(cmin, cmax)
-    if ticks[1] == 0 && cmin >= 1
-        ticks[1] = 1
-    end
+    ticks, viewmin, viewmax = Gadfly.optimize_ticks(cmin, cmax, strict_span=strict_span)
+    ticks[1] == 0 && cmin >= 1 && !strict_span && (ticks[1] = 1)
 
     cmin, cmax = ticks[1], ticks[end]
     cspan = cmax != cmin ? cmax - cmin : 1.0

--- a/test/testscripts/issue723.jl
+++ b/test/testscripts/issue723.jl
@@ -1,0 +1,13 @@
+using Colors, Gadfly, RDatasets
+
+set_default_plot_size(10cm, 8cm)
+
+iris = dataset("datasets", "iris")
+palettef = Scale.lab_gradient(range(HSV(250,1,1), stop=HSV(0,1,1), length=100)...)
+colkey = Guide.colorkey(title="Petal\nlength")
+
+plot(iris, x=:SepalLength, y=:SepalWidth, color=:PetalLength,
+    shape=:Species, Guide.shapekey(pos=[4,8]), colkey,
+    Scale.color_continuous(colormap=palettef, minvalue=0, maxvalue=7)
+)
+

--- a/test/testscripts/lab_gradient.jl
+++ b/test/testscripts/lab_gradient.jl
@@ -1,11 +1,13 @@
 using Gadfly
 
-set_default_plot_size(6inch, 3inch)
+set_default_plot_size(21cm, 8cm)
 
 # Issue #678
-x = repeat(collect(1:10), inner=[10])
-y = repeat(collect(1:10), outer=[10])
-plot(x=x,y=y,color=x+y, Geom.rectbin,
-            Scale.ContinuousColorScale(Scale.lab_gradient(colorant"green",
-                                                          colorant"white",
-                                                          colorant"red")))
+
+x = repeat(collect(1:10), inner=[10]) .-0.5
+y = repeat(collect(1:10), outer=[10]) .-0.5
+palettef1 = Scale.lab_gradient(colorant"green", colorant"white", colorant"red")
+palettef2 = Scale.lab_gradient(["blue", "ghostwhite","red"]...)
+p1 = plot(x=x,y=y,color=x+y, Geom.rectbin, Scale.ContinuousColorScale(palettef1))
+p2 = plot(x=x,y=y,color=x+y, Geom.rectbin, Scale.ContinuousColorScale(palettef2))
+hstack(p1, p2)


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR
- Enables `strict_span` for `Gadfly.optimize_ticks()` in continuous color scales
- Adds docstring for `Scale.lab_gradient`
- closes #723

### Example
```julia
iris = dataset("datasets", "iris")
palettef = Scale.lab_gradient(range(HSV(250,1,1), stop=HSV(0,1,1), length=100)...)
colkey = Guide.colorkey(title="Petal\nlength")

p1 = plot(iris, x=:SepalLength, y=:SepalWidth, color=:PetalLength, colkey)
p2 = plot(iris, x=:SepalLength, y=:SepalWidth, color=:PetalLength,
    shape=:Species, Guide.shapekey(pos=[4,8]), colkey,
    Scale.color_continuous(colormap=palettef, minvalue=0, maxvalue=7)
)
hstack(p1, p2)
```
![color_continuous_strict_span](https://user-images.githubusercontent.com/18226881/52528209-bfba9d80-2d2c-11e9-95b0-07b598e0b6c5.png)

