### PR TITLE
put only a single copy of gadfly.js and snap.svg-min.js in text/html output

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -1070,14 +1070,7 @@ function display(d::GadflyDisplay, ::MIME"text/html", p::Union{Plot,Compose.Cont
             <title>Gadfly Plot</title>
             <meta charset="utf-8">
           </head>
-            <body style="margin:0">
-            <script charset="utf-8">
-                $(read(Compose.snapsvgjs, String))
-            </script>
-            <script charset="utf-8">
-                $(read(gadflyjs, String))
-            </script>
-
+          <body style="margin:0">
             $(plotsvg)
           </body>
         </html>


### PR DESCRIPTION
title says it all.  a copy is already put in by the preceding call to SVGJS.