### PR TITLE
fix tests on julia 0.7

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1099,7 +1099,7 @@ function apply_statistic(stat::BoxplotStatistic,
 
     isa(aes_x, IndirectArray) && (aes.x = discretize_make_ia(aes.x, aes_x.values))
 
-    colorflag && (aes.color = discretize_make_ia(first.(keys(grouped_y)), aes.color.values))
+    colorflag && (aes.color = discretize_make_ia([first(k) for k in keys(grouped_y)], aes.color.values))
 
     Stat.apply_statistic(Stat.dodge(), scales, coord, aes)
 
@@ -2060,7 +2060,7 @@ function apply_statistic(stat::DodgeStatistic,
     
     if stat.position==:dodge
         nbars == length(aes.color) && return
-        offset = range(-0.5+0.5/nbars, 0.5, step=1/nbars)
+        offset = range(-0.5+0.5/nbars, stop=0.5, step=1/nbars)
         dodge = getindex(offset, aes.color.index)
         setfield!(aes, stat.axis, vals.+dodge)
     elseif stat.position==:stack


### PR DESCRIPTION
- [x ] I've run the regression tests
- [x ] I've `squash`'ed or `fixup`'ed junk commits with git-rebase

test/testscripts/colored_boxplot.jl was failing on julia 0.7.  this fixes that.

worth nothing that there appears to be a breaking change with julia 1.1 regarding broadcasting:

```
$ julia7
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: https://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.7.0 (2018-08-08 06:46 UTC)
 _/ |\__'_|_|_|\__'_|  |  Official http://julialang.org/ release
|__/                   |  x86_64-apple-darwin14.5.0

julia> first.(keys(Dict('a'=>1,'b'=>2)))
┌ Warning: broadcast will default to iterating over its arguments in the future. Wrap arguments of
│ type `x::Base.KeySet{Char,Dict{Char,Int64}}` with `Ref(x)` to ensure they broadcast as "scalar" elements.
│   caller = ip:0x0
└ @ Core :-1
'a': ASCII/Unicode U+0061 (category Ll: Letter, lowercase)

julia> 

$ julia1
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.1.0 (2019-01-21)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> first.(keys(Dict('a'=>1,'b'=>2)))
2-element Array{Char,1}:
 'a'
 'b'
```
