### PR TITLE
Remove usage of fieldnames function at runtime where possible

### DIFF
--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -93,11 +93,14 @@ const NumericalAesthetic =
     pad_categorical_y, Union{Missing,Bool}, missing
 end
 
+# Calculating fieldnames at runtime is expensive
+const valid_aesthetics = fieldnames(Aesthetics)
+
 
 function show(io::IO, data::Aesthetics)
     maxlen = 0
     print(io, "Aesthetics(")
-    for name in fieldnames(Aesthetics)
+    for name in valid_aesthetics
         val = getfield(data, name)
         if !ismissing(val) && val != nothing
             print(io, "\n  ", string(name), "=")
@@ -136,7 +139,7 @@ getindex(aes::Aesthetics, i::Integer, j::AbstractString) = getfield(aes, Symbol(
 # Return the set of variables that are non-nothing.
 function defined_aesthetics(aes::Aesthetics)
     vars = Set{Symbol}()
-    for name in fieldnames(Aesthetics)
+    for name in valid_aesthetics
         getfield(aes, name) === nothing || push!(vars, name)
     end
     vars
@@ -194,7 +197,7 @@ end
 # Modifies: a
 #
 function update!(a::Aesthetics, b::Aesthetics)
-    for name in fieldnames(Aesthetics)
+    for name in valid_aesthetics
         issomething(getfield(b, name)) && setfield(a, name, getfield(b, name))
     end
     nothing
@@ -226,7 +229,7 @@ json(a::Aesthetics) = join([string(a, ":", json(getfield(a, var))) for var in ae
 function concat(aess::Aesthetics...)
     cataes = Aesthetics()
     for aes in aess
-        for var in fieldnames(Aesthetics)
+        for var in valid_aesthetics
             if var in [:xviewmin, :yviewmin]
                 mu, mv = getfield(cataes, var), getfield(aes, var)
                 setfield!(cataes, var,
@@ -397,7 +400,7 @@ end
 function inherit!(a::Aesthetics, b::Aesthetics;
                   clobber=[])
     clobber_set = Set{Symbol}(clobber)
-    for field in fieldnames(Aesthetics)
+    for field in valid_aesthetics
         aval = getfield(a, field)
         bval = getfield(b, field)
         if field in clobber_set

--- a/src/data.jl
+++ b/src/data.jl
@@ -43,6 +43,8 @@
     titles, Dict{Symbol, AbstractString}, Dict{Symbol, AbstractString}()
 end
 
+# Calculating fieldnames at runtime is expensive
+const data_fields = fieldnames(Data)
 
 
 # Produce a new Data instance chaining the values of one or more others.
@@ -58,7 +60,7 @@ end
 #
 function chain(ds::Data...)
     chained_data = Data()
-    for name in fieldnames(Data)
+    for name in data_fields
         vs = Any[getfield(d, name) for d in ds]
         vs = Any[v for v in filter(issomething, vs)]
         if isempty(vs)
@@ -75,7 +77,7 @@ end
 function show(io::IO, data::Data)
     maxlen = 0
     print(io, "Data(")
-    for name in fieldnames(Data)
+    for name in data_fields
         if getfield(data, name) != nothing
             print(io, "\n  ", string(name), "=")
             show(io, getfield(data, name))

--- a/src/mapping.jl
+++ b/src/mapping.jl
@@ -52,7 +52,6 @@ end # module Row
 #   A new mapping with aliases evaluated and unrecognized aesthetics removed.
 #
 function cleanmapping(mapping::Dict)
-    valid_aesthetics = fieldnames(Aesthetics)
     cleaned = Dict{Symbol, Any}()
     for (key, val) in mapping
         # skip the "order" pesudo-aesthetic, used to order layers

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -10,7 +10,8 @@ using IndirectArrays
 using CategoricalArrays
 using Printf
 
-import Gadfly: element_aesthetics, isconcrete, concrete_length, discretize_make_ia, aes2str
+import Gadfly: element_aesthetics, isconcrete, concrete_length, discretize_make_ia,
+    aes2str, valid_aesthetics
 import Distributions: Distribution
 
 include("color_misc.jl")
@@ -236,7 +237,7 @@ function apply_scale(scale::ContinuousScale,
                 label_var = Symbol(var, "_label")
             end
 
-            if in(label_var, Set(fieldnames(typeof(aes))))
+            if in(label_var, valid_aesthetics)
                 setfield!(aes, label_var, make_labeler(scale))
             end
         end
@@ -391,7 +392,7 @@ function apply_scale(scale::DiscreteScale, aess::Vector{Gadfly.Aesthetics}, data
                 labeler = explicit_labeler
             end
 
-            in(label_var, Set(fieldnames(typeof(aes)))) && setfield!(aes, label_var, labeler)
+            in(label_var, valid_aesthetics) && setfield!(aes, label_var, labeler)
         end
     end
 end

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -323,7 +323,7 @@ function apply_statistic(stat::HistogramStatistic,
         x_min -= 0.5 # adjust the left side of the bar
         binwidth = 1.0
     else
-        lims = fieldnames(typeof(stat.limits))
+        lims = keys(stat.limits)
         x_min = in(:min, lims) ? stat.limits.min : Gadfly.concrete_minimum(vals)
 
         isdiscrete = false


### PR DESCRIPTION
Introspection using fieldnames at runtime can have a large negative
effect on code speed.

For time-to-first-plot, which is all I'm interested in at the moment,
these changes give a 5-10% improvement on simple cases I tested.

Before:

```julia
const x = collect(1:2000)
const y = rand(2000)

@time p = plot(x=x, y=y, Geom.line);
 0.637450 seconds (947.25 k allocations: 48.127 MiB, 5.71% gc time)

@time draw(SVG("test.svg", 4cm, 4cm), p)
 60.589051 seconds (82.63 M allocations: 4.113 GiB, 5.98% gc time)
```

After:

```julia
const x = collect(1:2000)
const y = rand(2000)

@time p = plot(x=x, y=y, Geom.line);
 0.594075 seconds (941.17 k allocations: 47.927 MiB, 4.30% gc time)

@time draw(SVG("test.svg", 4cm, 4cm), p)
 54.662001 seconds (81.76 M allocations: 4.070 GiB, 5.74% gc time)
```

I didn't always get the full 10% increase shown here, but it was
consistently better across a few runs.
