### PR TITLE
WIP: Time-to-first-plot improvements

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -388,14 +388,14 @@ function render_prepare(plot::Plot)
     # they are missing.
     datas = Array{Data}(undef, length(plot.layers))
     for (i, layer) in enumerate(plot.layers)
-        if layer.data_source === nothing && isempty(layer.mapping)
+        if isnothing(layer.data_source) && isempty(layer.mapping)
             layer.data_source = plot.data_source
             layer.mapping = plot.mapping
             datas[i] = plot.data
         else
             datas[i] = Data()
 
-            if layer.data_source === nothing
+            if isnothing(layer.data_source)
                 layer.data_source = plot.data_source
             end
 
@@ -416,7 +416,7 @@ function render_prepare(plot::Plot)
         if isa(layer.geom, Geom.SubplotGeometry)
             for subplot_layer in layers(layer.geom)
                 subplot_data = Data()
-                if subplot_layer.data_source === nothing
+                if isnothing(subplot_layer.data_source)
                     subplot_layer.data_source = layer.data_source
                 end
 
@@ -434,7 +434,7 @@ function render_prepare(plot::Plot)
     coord = plot.coord
     for layer in plot.layers
         coord_type = element_coordinate_type(layer.geom)
-        if coord === nothing
+        if isnothing(coord)
             coord = coord_type()
         elseif typeof(coord) != coord_type
             error("Plot uses multiple coordinates: $(typeof(coord)) and $(coord_type)")
@@ -503,7 +503,7 @@ function render_prepare(plot::Plot)
 
     unscaled_aesthetics = setdiff(used_aesthetics, scaled_aesthetics)
 
-    _theme(plt, lyr) = lyr.theme == nothing ? plt.theme : lyr.theme
+    _theme(plt, lyr) = isnothing(lyr.theme) ? plt.theme : lyr.theme
 
     # Add default scales for statistics.
     layer_stats_with_theme = map(plot.layers, layer_stats) do l, stats
@@ -532,17 +532,17 @@ function render_prepare(plot::Plot)
         in(var, mapped_aesthetics) || continue
 
         var_data = getfield(plot.data, var)
-        if var_data == nothing
+        if isnothing(var_data)
             for data in datas
                 var_layer_data = getfield(data, var)
-                if var_layer_data != nothing
+                if issomething(var_layer_data)
                     var_data = var_layer_data
                     break
                 end
             end
         end
 
-        var_data == nothing && continue
+        isnothing(var_data) && continue
 
         t = classify_data(var_data)
         if scale_exists(t, var)
@@ -560,7 +560,7 @@ function render_prepare(plot::Plot)
         t = :categorical
         for data in Iterators.flatten((datas, subplot_datas))
             val = getfield(data, var)
-            if val != nothing && val != :categorical
+            if issomething(val) && val != :categorical
                 t = classify_data(val)
             end
         end
@@ -659,24 +659,27 @@ function render_prepare(plot::Plot)
     keyvars = [:color, :shape]
     for (i, layer) in enumerate(plot.layers)
         for kv in keyvars
-            fflag = (getfield(layer_aess[i], Symbol(kv,"_key_title")) == nothing) && haskey(layer.mapping, kv) && !isa(layer.mapping[kv], AbstractArray)
+            fflag = (isnothing(getfield(layer_aess[i], Symbol(kv,"_key_title")))) &&
+                haskey(layer.mapping, kv) &&
+                !isa(layer.mapping[kv], AbstractArray)
             fflag && setfield!(layer_aess[i], Symbol(kv,"_key_title"), string(layer.mapping[kv]))
         end
     end
 
     for kv in keyvars
-        fflag = (getfield(layer_aess[1], Symbol(kv,"_key_title")) == nothing) && haskey(plot.mapping, kv) && !isa(plot.mapping[kv], AbstractArray)
+        fflag = (isnothing(getfield(layer_aess[1], Symbol(kv,"_key_title")))) &&
+            haskey(plot.mapping, kv) && !isa(plot.mapping[kv], AbstractArray)
         fflag && setfield!(layer_aess[1], Symbol(kv,"_key_title"), string(plot.mapping[kv]))
     end
 
     # Auto-update color scale if shape==color
     catdatas = vcat(datas, subplot_datas)
     shapev = getfield.(catdatas, :shape)
-    di = (shapev.!=nothing) .& (shapev.== getfield.(catdatas, :color))
+    di = issomething.(shapev) .& (shapev.== getfield.(catdatas, :color))
 
     supress_colorkey = false
     for (aes, data) in zip(layer_aess[di], catdatas[di])
-        aes.shape_key_title==nothing && (aes.shape_key_title=aes.color_key_title="Shape")
+        isnothing(aes.shape_key_title) && (aes.shape_key_title=aes.color_key_title="Shape")
         colorf = scales[:color].f
         scales[:color] =  Scale.color_discrete(colorf, levels=scales[:shape].levels, order=scales[:shape].order)
         Scale.apply_scale(scales[:color], [aes], Gadfly.Data(color=getfield(data,:color))  )
@@ -713,7 +716,7 @@ function render_prepare(plot::Plot)
 
     if !supress_keys
         for (KT, kv) in zip(keytypes, keyvars)
-            fflag = !all([getfield(aes, kv)==nothing for aes in [plot_aes, layer_aess...]])
+            fflag = !all([isnothing(getfield(aes, kv)) for aes in [plot_aes, layer_aess...]])
             fflag && !in(KT, explicit_guide_types) &&  push!(guides, KT())
         end
     end
@@ -756,7 +759,7 @@ function render(plot::Plot)
 
     ctx =  pad_inner(root_context, plot.theme.plot_padding...)
 
-    if plot.theme.background_color != nothing
+    if issomething(plot.theme.background_color)
         compose!(ctx, (context(order=-1000000),
                         fill(plot.theme.background_color),
                         stroke(nothing), rectangle()))
@@ -807,7 +810,7 @@ function render_prepared(plot::Plot,
                                           layer_aess), scales)
 
     # IV. Geometries
-    themes = Theme[layer.theme === nothing ? plot.theme : layer.theme
+    themes = Theme[isnothing(layer.theme) ? plot.theme : layer.theme
                    for layer in plot.layers]
     zips = trim_zip(plot.layers, layer_aess, layer_subplot_aess,
                     layer_subplot_datas, themes)
@@ -820,7 +823,7 @@ function render_prepared(plot::Plot,
     guide_contexts = Guide.PositionedGuide[]
     for guide in guides
         guide_context = render(guide, plot.theme, plot_aes, dynamic)
-        if !isnothing(guide_context)
+        if issomething(guide_context)
             append!(guide_contexts, guide_context)
         end
     end

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -653,7 +653,7 @@ function render_prepare(plot::Plot)
 
     # I. Scales
     layer_aess = Scale.apply_scales(IterTools.distinct(values(scales)),
-                                    datas..., subplot_datas...)
+                                    vcat(datas, subplot_datas))
 
     # set defaults for key titles
     keyvars = [:color, :shape]
@@ -809,28 +809,24 @@ function render_prepared(plot::Plot,
     # IV. Geometries
     themes = Theme[layer.theme === nothing ? plot.theme : layer.theme
                    for layer in plot.layers]
-    zips = trim_zip(plot.layers, layer_aess,
-                                                   layer_subplot_aess,
-                                                   layer_subplot_datas,
-               themes)
-
-    compose!(plot_context,
-             [compose(context(order=layer.order), render(layer.geom, theme, aes,
-                                                         subplot_aes, subplot_data,
-                                                         scales))
-              for (layer, aes, subplot_aes, subplot_data, theme) in zips]...)
+    zips = trim_zip(plot.layers, layer_aess, layer_subplot_aess,
+                    layer_subplot_datas, themes)
+    for (layer, aes, subplot_aes, subplot_data, theme) in zips
+        r = render(layer.geom, theme, aes, subplot_aes, subplot_data, scales)
+        compose!(plot_context, r)
+    end#for
 
     # V. Guides
-    guide_contexts = Any[]
+    guide_contexts = Guide.PositionedGuide[]
     for guide in guides
         guide_context = render(guide, plot.theme, plot_aes, dynamic)
-        if guide_context != nothing
+        if !isnothing(guide_context)
             append!(guide_contexts, guide_context)
         end
     end
 
     tbl = Guide.layout_guides(plot_context, coord,
-                              plot.theme, guide_contexts...)
+                              plot.theme, guide_contexts)
     if table_only
         return tbl
     end

--- a/src/coord.jl
+++ b/src/coord.jl
@@ -67,7 +67,7 @@ function first_concrete_aesthetic_value(aess::Vector{Gadfly.Aesthetics}, vars::V
     for var in vars
         for aes in aess
             vals = getfield(aes, var)
-            vals === nothing && continue
+            Gadfly.isnothing(vals) && continue
 
             if !isa(vals, AbstractArray)
                 vals = [vals]
@@ -106,7 +106,7 @@ function aesthetics_type(aess::Vector{Gadfly.Aesthetics},
     for var in vars
         for aes in aess
             vals = getfield(aes, var)
-            vals === nothing && continue
+            Gadfly.isnothing(vals) && continue
 
             if var == :outliers
                 if !isempty(vals)
@@ -153,11 +153,11 @@ function apply_coordinate(coord::Cartesian, aess::Vector{Gadfly.Aesthetics},
 
     xmin = xmax = first_concrete_aesthetic_value(aess, coord.xvars)
 
-    if xmin != nothing
+    if Gadfly.issomething(xmin)
         for var in coord.xvars
             for aes in aess
                 vals = getfield(aes, var)
-                vals === nothing && continue
+                Gadfly.isnothing(vals) && continue
 
                 if !isa(vals, AbstractArray)
                     vals = [vals]
@@ -169,11 +169,11 @@ function apply_coordinate(coord::Cartesian, aess::Vector{Gadfly.Aesthetics},
     end
 
     ymin = ymax = first_concrete_aesthetic_value(aess, coord.yvars)
-    if ymin != nothing
+    if Gadfly.issomething(ymin)
         for var in coord.yvars
             for aes in aess
                 vals = getfield(aes, var)
-                vals === nothing && continue
+                Gadfly.isnothing(vals) && continue
 
                 # Outliers is an odd aesthetic that needs special treatment.
                 if var == :outliers
@@ -196,40 +196,40 @@ function apply_coordinate(coord::Cartesian, aess::Vector{Gadfly.Aesthetics},
 
     # viewmin/max that is set explicitly should override min/max
     for aes in aess
-        if aes.xviewmin != nothing
-            xviewmin = xviewmin === nothing ? aes.xviewmin : min(xviewmin, aes.xviewmin)
+        if Gadfly.issomething(aes.xviewmin)
+            xviewmin = Gadfly.isnothing(xviewmin) ? aes.xviewmin : min(xviewmin, aes.xviewmin)
         end
 
-        if aes.xviewmax != nothing
-            xviewmax = xviewmax === nothing ? aes.xviewmax : max(xviewmax, aes.xviewmax)
+        if Gadfly.issomething(aes.xviewmax)
+            xviewmax = Gadfly.isnothing(xviewmax) ? aes.xviewmax : max(xviewmax, aes.xviewmax)
         end
 
-        if aes.yviewmin != nothing
-            yviewmin = yviewmin === nothing ? aes.yviewmin : min(yviewmin, aes.yviewmin)
+        if Gadfly.issomething(aes.yviewmin)
+            yviewmin = Gadfly.isnothing(yviewmin) ? aes.yviewmin : min(yviewmin, aes.yviewmin)
         end
 
-        if aes.yviewmax != nothing
-            yviewmax = yviewmax === nothing ? aes.yviewmax : max(yviewmax, aes.yviewmax)
+        if Gadfly.issomething(aes.yviewmax)
+            yviewmax = Gadfly.isnothing(yviewmax) ? aes.yviewmax : max(yviewmax, aes.yviewmax)
         end
     end
 
-    xmax = xviewmax === nothing ? xmax : max(xmax, xviewmax)
-    xmin = xviewmin === nothing ? xmin : min(xmin, xviewmin)
-    ymax = yviewmax === nothing ? ymax : max(ymax, yviewmax)
-    ymin = yviewmin === nothing ? ymin : min(ymin, yviewmin)
+    xmax = Gadfly.isnothing(xviewmax) ? xmax : max(xmax, xviewmax)
+    xmin = Gadfly.isnothing(xviewmin) ? xmin : min(xmin, xviewmin)
+    ymax = Gadfly.isnothing(yviewmax) ? ymax : max(ymax, yviewmax)
+    ymin = Gadfly.isnothing(yviewmin) ? ymin : min(ymin, yviewmin)
 
     # Hard limits set in Coord should override everything else
-    xmin = coord.xmin === nothing ? xmin : coord.xmin
-    xmax = coord.xmax === nothing ? xmax : coord.xmax
-    ymin = coord.ymin === nothing ? ymin : coord.ymin
-    ymax = coord.ymax === nothing ? ymax : coord.ymax
+    xmin = Gadfly.isnothing(coord.xmin) ? xmin : coord.xmin
+    xmax = Gadfly.isnothing(coord.xmax) ? xmax : coord.xmax
+    ymin = Gadfly.isnothing(coord.ymin) ? ymin : coord.ymin
+    ymax = Gadfly.isnothing(coord.ymax) ? ymax : coord.ymax
 
-    if xmin === nothing || !isfinite(xmin)
+    if Gadfly.isnothing(xmin) || !isfinite(xmin)
         xmin = 0.0
         xmax = 1.0
     end
 
-    if ymin === nothing || !isfinite(ymin)
+    if Gadfly.isnothing(ymin) || !isfinite(ymin)
         ymin = 0.0
         ymax = 1.0
     end

--- a/src/data.jl
+++ b/src/data.jl
@@ -76,7 +76,7 @@ function show(io::IO, data::Data)
     maxlen = 0
     print(io, "Data(")
     for name in fieldnames(Data)
-        if getfield(data, name) != nothing
+        if issomething(getfield(data, name))
             print(io, "\n  ", string(name), "=")
             show(io, getfield(data, name))
         end

--- a/src/dataframes.jl
+++ b/src/dataframes.jl
@@ -11,7 +11,7 @@ function meltdata(U::AbstractDataFrame, colgroups_::Vector{Col.GroupedColumn})
     vm = um
     grouped_columns = Set{Symbol}()
     for colgroup in colgroups
-        if colgroup.columns===nothing # null => group all columns
+        if isnothing(colgroup.columns) # null => group all columns
             vm *= un
             grouped_columns = copy(allcolumns)
         else
@@ -34,7 +34,7 @@ function meltdata(U::AbstractDataFrame, colgroups_::Vector{Col.GroupedColumn})
 
     # allocate vectors for grouped columns
     for (j, colgroup) in enumerate(colgroups)
-        cols = colgroup.columns===nothing ? allcolumns : colgroup.columns
+        cols = isnothing(colgroup.columns) ? allcolumns : colgroup.columns
 
         # figure the grouped common column type
         firstcol = U[first(cols)]
@@ -64,7 +64,7 @@ function meltdata(U::AbstractDataFrame, colgroups_::Vector{Col.GroupedColumn})
     col_indicators = Array{Symbol}(undef, vm, length(colgroups))
     row_indicators = Array{Int}(undef, vm, length(colgroups))
 
-    colidxs = [colgroup.columns===nothing ? collect(allcolumns) : colgroup.columns
+    colidxs = [isnothing(colgroup.columns) ? collect(allcolumns) : colgroup.columns
                for colgroup in colgroups]
 
     vi = 1

--- a/src/geom/bar.jl
+++ b/src/geom/bar.jl
@@ -74,7 +74,7 @@ function render_bar(geom::BarGeometry,
             svgclass("geometry"))
     end
 
-    cs = aes.color === nothing ? theme.default_color : aes.color
+    cs = isnothing(aes.color) ? theme.default_color : aes.color
     compose!(ctx, fill(cs), svgclass("geometry"))
     if isa(theme.bar_highlight, Function)
         compose!(ctx, stroke(theme.bar_highlight(theme.default_color)))
@@ -272,7 +272,7 @@ function render(geom::BarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
         error("Orientation must be :horizontal or :vertical")
     end
 
-    if aes.color === nothing
+    if isnothing(aes.color)
         ctx = render_bar(geom, theme, aes, geom.orientation)
     elseif geom.position == :stack
         if geom.orientation == :horizontal

--- a/src/geom/boxplot.jl
+++ b/src/geom/boxplot.jl
@@ -123,7 +123,7 @@ function render(geom::BoxplotGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
         svgclass("geometry"))
 
     # Outliers
-    if !geom.suppress_outliers && aes.outliers != nothing && !isempty(aes.outliers)
+    if !geom.suppress_outliers && issomething(aes.outliers) && !isempty(aes.outliers)
         xys = collect(Iterators.flatten(zip(cycle([x]), ys, cycle([c]))
                              for (x, ys, c) in zip(xs, aes.outliers, cs)))
         compose!(ctx, (context(),
@@ -133,7 +133,7 @@ function render(geom::BoxplotGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
     end
 
     # Middle
-    if aes.middle != nothing
+    if issomething(aes.middle)
         compose!(ctx, (
            context(order=1),
            Compose.line([[(x - fw/2, mid), (x + fw/2, mid)]

--- a/src/geom/errorbar.jl
+++ b/src/geom/errorbar.jl
@@ -110,7 +110,7 @@ function render(geom::YErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthe
         stroke([theme.stroke_color(c) for c in aes.color]),
         linewidth(theme.line_width))
 
-    (aes.color_key_continuous == true || aes.color == nothing) || compose!(ctx,
+    (aes.color_key_continuous == true || isnothing(aes.color)) || compose!(ctx,
             svgclass([svg_color_class_from_label(aes.color_label([c])[1]) for c in aes.color]))
 
     return ctx
@@ -148,7 +148,7 @@ function render(geom::XErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthe
         stroke([theme.stroke_color(c) for c in aes.color]),
         linewidth(theme.line_width))
 
-    (aes.color_key_continuous == true || aes.color == nothing) || compose!(ctx,
+    (aes.color_key_continuous == true || isnothing(aes.color)) || compose!(ctx,
             svgclass([svg_color_class_from_label(aes.color_label([c])[1])
                       for c in aes.color]))
 

--- a/src/geom/hvabline.jl
+++ b/src/geom/hvabline.jl
@@ -18,7 +18,7 @@ struct HLineGeometry <: Gadfly.GeometryElement
     tag::Symbol
 
     HLineGeometry(color, size, style, tag) =
-            new(color === nothing ? nothing : Gadfly.parse_colorant(color), size, style, tag)
+            new(isnothing(color) ? nothing : Gadfly.parse_colorant(color), size, style, tag)
 end
 HLineGeometry(; color=nothing, size=nothing, style=nothing, tag=empty_tag) =
         HLineGeometry(color, size, style, tag)
@@ -36,9 +36,9 @@ element_aesthetics(::HLineGeometry) = [:yintercept]
 function render(geom::HLineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     Gadfly.assert_aesthetics_defined("Geom.hline", aes, :yintercept)
 
-    color = geom.color === nothing ? theme.default_color : geom.color
-    size = geom.size === nothing ? theme.line_width : geom.size
-    style = geom.style === nothing ? theme.line_style[1] : geom.style
+    color = isnothing(geom.color) ? theme.default_color : geom.color
+    size = isnothing(geom.size) ? theme.line_width : geom.size
+    style = isnothing(geom.style) ? theme.line_style[1] : geom.style
 
     color = check_arguments(color, length(aes.yintercept))
     size = check_arguments(size, length(aes.yintercept))
@@ -65,7 +65,7 @@ struct VLineGeometry <: Gadfly.GeometryElement
     tag::Symbol
 
     VLineGeometry(color, size, style, tag) =
-            new(color === nothing ? nothing : Gadfly.parse_colorant(color), size, style, tag)
+            new(isnothing(color) ? nothing : Gadfly.parse_colorant(color), size, style, tag)
 end
 VLineGeometry(; color=nothing, size=nothing, style=nothing, tag=empty_tag) =
         VLineGeometry(color, size, style, tag)
@@ -83,9 +83,9 @@ element_aesthetics(::VLineGeometry) = [:xintercept]
 function render(geom::VLineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     Gadfly.assert_aesthetics_defined("Geom.vline", aes, :xintercept)
 
-    color = geom.color === nothing ? theme.default_color : geom.color
-    size = geom.size === nothing ? theme.line_width : geom.size
-    style = geom.style === nothing ? theme.line_style[1] : geom.style
+    color = isnothing(geom.color) ? theme.default_color : geom.color
+    size = isnothing(geom.size) ? theme.line_width : geom.size
+    style = isnothing(geom.style) ? theme.line_style[1] : geom.style
 
     color = check_arguments(color, length(aes.xintercept))
     size = check_arguments(size, length(aes.xintercept))
@@ -112,7 +112,7 @@ struct ABLineGeometry <: Gadfly.GeometryElement
     tag::Symbol
 
     ABLineGeometry(color, size, style, tag) =
-            new(color === nothing ? nothing : Gadfly.parse_colorant(color), size, style, tag)
+            new(isnothing(color) ? nothing : Gadfly.parse_colorant(color), size, style, tag)
 end
 ABLineGeometry(; color=nothing, size=nothing, style=nothing, tag::Symbol=empty_tag) =
         ABLineGeometry(color, size, style, tag)
@@ -131,19 +131,19 @@ const abline = ABLineGeometry
 element_aesthetics(geom::ABLineGeometry) = [:intercept, :slope]
 
 function render(geom::ABLineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
-    if aes.intercept == nothing && aes.slope == nothing
+    if isnothing(aes.intercept) && isnothing(aes.slope)
         aes.intercept = [0]
         aes.slope = [1]
-    elseif aes.intercept == nothing
+    elseif isnothing(aes.intercept)
         aes.intercept = fill(0,length(aes.slope))
-    elseif aes.slope == nothing
+    elseif isnothing(aes.slope)
         aes.slope = fill(1,length(aes.intercept))
     end
     Gadfly.assert_aesthetics_equal_length("Geom.line", aes, element_aesthetics(geom)...)
 
-    color = geom.color === nothing ? theme.default_color : geom.color
-    size = geom.size === nothing ? theme.line_width : geom.size
-    style = geom.style === nothing ? theme.line_style[1] : geom.style
+    color = isnothing(geom.color) ? theme.default_color : geom.color
+    size = isnothing(geom.size) ? theme.line_width : geom.size
+    style = isnothing(geom.style) ? theme.line_style[1] : geom.style
 
     color = check_arguments(color, length(aes.intercept))
     size = check_arguments(size, length(aes.intercept))

--- a/src/geom/label.jl
+++ b/src/geom/label.jl
@@ -50,7 +50,7 @@ function deferred_label_context(geom::LabelGeometry,
 
     num_labels = length(aes.label)
 
-    if aes.size == nothing
+    if isnothing(aes.size)
         padding = fill(theme.point_size, num_labels) .+ theme.label_padding
     else
         padding = aes.size .+ theme.label_padding
@@ -279,7 +279,7 @@ function render(geom::LabelGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
         end
 
         hpos, vpos, xoff, yoff = label_layouts[geom.position]
-        if aes.size == nothing
+        if isnothing(aes.size)
             offsets = [(xoff*(theme.point_size + theme.label_padding),
                         yoff*(theme.point_size + theme.label_padding))]
         else

--- a/src/geom/point.jl
+++ b/src/geom/point.jl
@@ -67,7 +67,7 @@ function render(geom::PointGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
     for (x, y, color, size, shape, alpha) in Compose.cyclezip(aes.x, aes.y, aes.color, aes.size, aes.shape, aes_alpha)
         shapefun = typeof(shape) <: Function ? shape : theme.point_shapes[shape]
         sizeval = typeof(size) <: Int ? interpolate_size(size) : size
-        strokecolor = aes.color_key_continuous != nothing && aes.color_key_continuous ?
+        strokecolor = issomething(aes.color_key_continuous) && aes.color_key_continuous ?
                     theme.continuous_highlight_color(color) :
                     theme.discrete_highlight_color(color)
         class = svg_color_class_from_label(aes.color_label([color])[1])

--- a/src/geom/rectbin.jl
+++ b/src/geom/rectbin.jl
@@ -94,14 +94,14 @@ function render(geom::RectangularBinGeometry, theme::Gadfly.Theme, aes::Gadfly.A
 
     allvisible = true
     for c in cs
-        if c == nothing
+        if isnothing(c)
             allvisible = false
             break
         end
     end
 
     if !allvisible
-        visibility = cs .!= nothing
+        visibility = issomething.(cs)
         cs = cs[visibility]
         xmin = xmin[visibility]
         xmax = xmax[visibility]

--- a/src/geom/segment.jl
+++ b/src/geom/segment.jl
@@ -82,7 +82,7 @@ function render(geom::SegmentGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
 
     if geom.arrow
         check = [aes.xviewmin, aes.xviewmax, aes.yviewmin, aes.yviewmax ]
-        if any( map(x -> x === nothing, check) )
+        if any(map(isnothing, check))
             error("For Geom.vector, Scale minvalue and maxvalue must be manually provided for both axes")
         end
          xyrange = [aes.xviewmax-aes.xviewmin, aes.yviewmax-aes.yviewmin]

--- a/src/geom/subplot.jl
+++ b/src/geom/subplot.jl
@@ -181,7 +181,7 @@ function render(geom::SubplotGrid, theme::Gadfly.Theme,
                            Gadfly.Aesthetics[layer_aes_grid[k][i, j]
                                              for k in 1:length(geom.layers)],
                            Gadfly.Data[layer_data_grid[k][i, j]
-                                       for k in 1:length(geom.layers)]...)
+                                       for k in 1:length(geom.layers)])
 
         for (k, stats) in enumerate(layer_stats)
             Stat.apply_statistics(stats, scales, coord, layer_aes_grid[k][i, j])

--- a/src/geom/subplot.jl
+++ b/src/geom/subplot.jl
@@ -136,7 +136,7 @@ function render(geom::SubplotGrid, theme::Gadfly.Theme,
         inherited_aes = element_aesthetics(layer.geom)
         push!(inherited_aes, :xgroup, :ygroup)
         for var in inherited_aes
-            if getfield(layer_aes, var) === nothing
+            if isnothing(getfield(layer_aes, var))
                 setfield!(layer_aes, var, getfield(superplot_aes, var))
             end
         end
@@ -144,17 +144,17 @@ function render(geom::SubplotGrid, theme::Gadfly.Theme,
  # z
     for (layer_data, layer_aes) in zip(subplot_layer_datas, subplot_layer_aess)
         z = getfield(layer_data, :z)
-        (z != nothing) && setfield!(layer_aes, :z, z)
+        (issomething(z)) && setfield!(layer_aes, :z, z)
     end
 
     # work out the grid size
     m = 1
     n = 1
     for layer_aes in subplot_layer_aess
-        if layer_aes.xgroup != nothing
+        if issomething(layer_aes.xgroup)
             m = max(m, maximum(layer_aes.xgroup))
         end
-        if layer_aes.ygroup != nothing
+        if issomething(layer_aes.ygroup)
             n = max(n, maximum(layer_aes.ygroup))
         end
     end
@@ -315,7 +315,7 @@ function render(geom::SubplotGrid, theme::Gadfly.Theme,
         if i == n
             push!(guides, get(geom.guides, Guide.XTicks, Guide.xticks()))
 
-            if superplot_aes.xgroup !== nothing
+            if issomething(superplot_aes.xgroup)
                 push!(guides, get(geom.guides, Guide.XLabel, Guide.xlabel(xlabels[j])))
             end
         else
@@ -326,7 +326,7 @@ function render(geom::SubplotGrid, theme::Gadfly.Theme,
         if j == 1
             joff += 1
             push!(guides, get(geom.guides, Guide.YTicks, Guide.yticks()))
-            if superplot_aes.ygroup !== nothing
+            if issomething(superplot_aes.ygroup)
                 joff += 1
                 push!(guides, get(geom.guides, Guide.YLabel, Guide.ylabel(ylabels[i])))
             end
@@ -349,7 +349,7 @@ function render(geom::SubplotGrid, theme::Gadfly.Theme,
         # copy over the correct units, since we are reparenting the children
         for u in 1:size(subtbl, 1), v in 1:size(subtbl, 2)
             for child in subtbl[u, v]
-                if child.units===nothing
+                if isnothing(child.units)
                     child.units = subtbl.units
                 end
             end

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -13,7 +13,7 @@ import Compose.combine # Prevent DataFrame.combine from taking over.
 import Gadfly: render, layers, element_aesthetics, inherit, escape_id,
                default_statistic, default_scales, element_coordinate_type,
                ScaleElement, svg_color_class_from_label, isconcrete,
-               concretize, discretize_make_ia
+               concretize, discretize_make_ia, isnothing, issomething
 import IterTools: distinct, takestrict
 import Compat.Iterators: cycle, product, repeated
 

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -9,7 +9,7 @@ using IterTools
 using JSON
 
 import Gadfly: render, escape_id, default_statistic, jsdata, jsplotdata,
-               svg_color_class_from_label
+               svg_color_class_from_label, isnothing, issomething
 
 
 # Where the guide should be placed in relation to the plot.
@@ -35,7 +35,7 @@ const questionmark = QuestionMark
 
 function render(guide::QuestionMark, theme::Gadfly.Theme,
                 aes::Gadfly.Aesthetics)
-    text_color = theme.background_color == nothing ?
+    text_color = isnothing(theme.background_color) ?
             colorant"black" : distinguishable_colors(2,theme.background_color)[2]
     text_box = compose!( context(),
         text(1w,0h+2px,"?",hright,vtop),
@@ -64,7 +64,7 @@ const helpscreen = HelpScreen
 
 function render(guide::HelpScreen, theme::Gadfly.Theme,
                 aes::Gadfly.Aesthetics)
-    box_color = theme.background_color == nothing ?
+    box_color = isnothing(theme.background_color) ?
             colorant"black" : distinguishable_colors(2,theme.background_color)[2]
     text_color = distinguishable_colors(2,box_color)[2]
     text_strings = ["h,j,k,l,arrows,drag to pan",
@@ -104,7 +104,7 @@ const crosshair = CrossHair
 
 function render(guide::CrossHair, theme::Gadfly.Theme,
                 aes::Gadfly.Aesthetics)
-    text_color = theme.background_color == nothing ?
+    text_color = isnothing(theme.background_color) ?
             colorant"black" : distinguishable_colors(2,theme.background_color)[2]
     text_box = compose!(
         context(),
@@ -262,7 +262,7 @@ function render_discrete_color_key(colors::Vector{C},
                     fill(theme.key_label_color))
 
                 col = compose!(context(xpos, yoff), swatches, swatch_labels)
-                if aes_color_label != nothing
+                if issomething(aes_color_label)
                     classes = [svg_color_class_from_label(aes_color_label([c])[1]) for c in cs]
                     #class_jscalls = ["data(\"color_class\", \"$(c)\")"
                                      #for c in classes]
@@ -395,7 +395,7 @@ function render(guide::ColorKey, theme::Gadfly.Theme,
 
     (theme.key_position == :none || isempty(aes.color_key_colors)) && return PositionedGuide[]
     gpos = guide.pos
-    (theme.key_position == :inside && gpos === nothing) &&  (gpos = [0.7w, 0.25h])
+    (theme.key_position == :inside && isnothing(gpos)) &&  (gpos = [0.7w, 0.25h])
 
     used_colors = Set{Color}()
     colors = Array{Color}(undef, 0) # to preserve ordering
@@ -404,18 +404,18 @@ function render(guide::ColorKey, theme::Gadfly.Theme,
     continuous_guide = false
     guide_title = guide.title
 
-    if guide_title === nothing && aes.color_key_title !== nothing
+    if isnothing(guide_title) && issomething(aes.color_key_title)
         guide_title = aes.color_key_title
     end
 
-    if aes.color_key_colors != nothing &&
-       aes.color_key_continuous != nothing &&
+    if issomething(aes.color_key_colors) &&
+       issomething(aes.color_key_continuous) &&
        aes.color_key_continuous
         continuous_guide = true
     end
 
     color_key_labels = aes.color_label(keys(aes.color_key_colors))
-    if !continuous_guide && (guide.labels != nothing)
+    if !continuous_guide && issomething(guide.labels)
         color_key_labels = guide.labels
     end
 
@@ -430,7 +430,7 @@ function render(guide::ColorKey, theme::Gadfly.Theme,
         end
     end
 
-    if guide_title === nothing
+    if isnothing(guide_title)
         guide_title = "Color"
     end
 
@@ -457,7 +457,7 @@ function render(guide::ColorKey, theme::Gadfly.Theme,
                                          title_width, theme)
     end
 
-    if aes.shape != nothing
+    if issomething(aes.shape)
         # TODO: Draw key for shapes. We need to think about how to make this
         # work. Do we need to optimize number of columns for shape and size
         # keys? I'm guessing it's not worth it.
@@ -469,7 +469,7 @@ function render(guide::ColorKey, theme::Gadfly.Theme,
     end
 
     position = right_guide_position
-    if gpos != nothing
+    if issomething(gpos)
         position = over_guide_position
         ctxs = [compose(context(), (context(gpos[1],gpos[2]), ctxs[1]))]
     elseif theme.key_position == :left
@@ -517,11 +517,11 @@ function render(guide::ManualColorKey, theme::Gadfly.Theme,
 
     guide_title = guide.title
 
-    if guide_title === nothing && aes.color_key_title !== nothing
+    if isnothing(guide_title) && issomething(aes.color_key_title)
         guide_title = aes.color_key_title
     end
 
-    if guide_title === nothing
+    if isnothing(guide_title)
         guide_title = "Color"
     end
 
@@ -569,11 +569,11 @@ visibility.  `ticks` can also be an array of locations, or `nothing`.
 const xticks = XTicks
 
 default_statistic(guide::XTicks) =
-    guide.ticks == nothing ? Stat.identity() : Stat.xticks(ticks=guide.ticks)
+    isnothing(guide.ticks) ? Stat.identity() : Stat.xticks(ticks=guide.ticks)
 
 function render(guide::XTicks, theme::Gadfly.Theme,
                 aes::Gadfly.Aesthetics, dynamic::Bool=true)
-    guide.ticks == nothing && return PositionedGuide[]
+    isnothing(guide.ticks) && return PositionedGuide[]
 
     if Gadfly.issomething(aes.xtick)
         ticks = aes.xtick
@@ -740,7 +740,7 @@ visibility.  `ticks` can also be an array of locations, or `nothing`.
 const yticks = YTicks
 
 function default_statistic(guide::YTicks)
-    if guide.ticks == nothing
+    if isnothing(guide.ticks)
         return Stat.identity()
     else
         return Stat.yticks(ticks=guide.ticks)
@@ -749,7 +749,7 @@ end
 
 function render(guide::YTicks, theme::Gadfly.Theme,
                 aes::Gadfly.Aesthetics, dynamic::Bool=true)
-    if guide.ticks == nothing
+    if isnothing(guide.ticks)
         return PositionedGuide[]
     end
 
@@ -919,7 +919,7 @@ const xlabel = XLabel
 
 function render(guide::XLabel, theme::Gadfly.Theme,
                 aes::Gadfly.Aesthetics)
-    if guide.label === nothing || isempty(guide.label)
+    if isnothing(guide.label) || isempty(guide.label)
         return nothing
     end
 
@@ -986,7 +986,7 @@ const ylabel = YLabel
 
 
 function render(guide::YLabel, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
-    if guide.label === nothing || isempty(guide.label)
+    if isnothing(guide.label) || isempty(guide.label)
         return nothing
     end
 
@@ -1044,7 +1044,7 @@ const title = Title
 
 function render(guide::Title, theme::Gadfly.Theme,
                 aes::Gadfly.Aesthetics)
-    if guide.label === nothing || isempty(guide.label)
+    if isnothing(guide.label) || isempty(guide.label)
         return nothing
     end
 
@@ -1160,9 +1160,9 @@ function layout_guides(plot_context::Context,
     aspect_ratio = nothing
     if isa(coord, Gadfly.Coord.cartesian)
         if coord.fixed
-            aspect_ratio = plot_context.units===nothing ? 1.0 :
-                     abs(plot_context.units.width / plot_context.units.height)
-        elseif coord.aspect_ratio != nothing
+            aspect_ratio = isnothing(plot_context.units) ? 1.0 :
+                abs(plot_context.units.width / plot_context.units.height)
+        elseif issomething(coord.aspect_ratio)
             aspect_ratio = coord.aspect_ratio
         end
     end
@@ -1172,7 +1172,7 @@ function layout_guides(plot_context::Context,
     i = 1
     for (ctxs, order) in guides[top_guide_position]
         for ctx in ctxs
-            if ctx.units===nothing && plot_units!==nothing
+            if isnothing(ctx.units) && issomething(plot_units)
                 ctx.units = UnitBox(plot_units, toppad=0mm, bottompad=0mm)
             end
         end
@@ -1183,7 +1183,7 @@ function layout_guides(plot_context::Context,
     i += 1
     for (ctxs, order) in guides[bottom_guide_position]
         for ctx in ctxs
-            if ctx.units===nothing && plot_units!==nothing
+            if isnothing(ctx.units) && issomething(plot_units)
                 ctx.units = UnitBox(plot_units, toppad=0mm, bottompad=0mm)
             end
         end
@@ -1195,7 +1195,7 @@ function layout_guides(plot_context::Context,
     j = 1
     for (ctxs, order) in guides[left_guide_position]
         for ctx in ctxs
-            if ctx.units===nothing && plot_units!==nothing
+            if isnothing(ctx.units) && issomething(plot_units)
                 ctx.units = UnitBox(plot_units, leftpad=0mm, rightpad=0mm)
             end
         end
@@ -1206,7 +1206,7 @@ function layout_guides(plot_context::Context,
     j += 1
     for (ctxs, order) in guides[right_guide_position]
         for ctx in ctxs
-            if ctx.units===nothing && plot_units!==nothing
+            if isnothing(ctx.units) && issomething(plot_units)
                 ctx.units = UnitBox(plot_units, leftpad=0mm, rightpad=0mm)
             end
         end

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -125,10 +125,10 @@ end
 # A guide graphic is a position associated with one or more contexts.
 # Multiple contexts represent multiple layout possibilites that will be
 # optimized over.
-struct PositionedGuide
+struct PositionedGuide{P<:GuidePosition}
     ctxs::Vector{Context}
     order::Int
-    position::GuidePosition
+    position::P
 end
 
 
@@ -1129,7 +1129,7 @@ end
 function layout_guides(plot_context::Context,
                        coord::Gadfly.CoordinateElement,
                        theme::Gadfly.Theme,
-                       positioned_guides::PositionedGuide...)
+                       positioned_guides::Vector{PositionedGuide})
     # Organize guides by position
     guides = DefaultDict(() -> (Tuple{Vector{Context}, Int})[])
     for positioned_guide in positioned_guides

--- a/src/guide/keys.jl
+++ b/src/guide/keys.jl
@@ -32,11 +32,11 @@ function Guide.render(guide::Guide.ShapeKey, theme::Gadfly.Theme, aes::Gadfly.Ae
 
     # Aesthetics for keys: shape_key_title, shape_label (Function), shape_key_shapes (AbstractDict)    
     nshapes = length(unique(aes.shape))
-    guide_title = (guide.title!="Shape" || aes.shape_key_title==nothing) ? guide.title : aes.shape_key_title
+    guide_title = (guide.title!="Shape" || isnothing(aes.shape_key_title)) ? guide.title : aes.shape_key_title
     shape_key_labels = !(guide.labels==[""]) ? guide.labels : aes.shape_label(1:nshapes)
     
     colors = [nothing]
-    if (aes.shape_key_title !=nothing)  && (aes.color_key_title==aes.shape_key_title)
+    if issomething(aes.shape_key_title)  && (aes.color_key_title==aes.shape_key_title)
         colors = collect(keys(aes.color_key_colors))
     end
     
@@ -70,8 +70,8 @@ function render_discrete_key(labels::Vector{String}, title_ctx::Context, title_w
 
     n = max(length(colors), length(shapes))
     shape1 = shapes[1]
-    shapes = (shape1==nothing) ? fill(theme.key_swatch_shape, n) : theme.point_shapes[shapes]
-    (colors[1]==nothing) && (colors = fill((theme.key_swatch_color==nothing) ? theme.default_color : theme.key_swatch_color, n))
+    shapes = isnothing(shape1) ? fill(theme.key_swatch_shape, n) : theme.point_shapes[shapes]
+    (isnothing(colors[1])) && (colors = fill((isnothing(theme.key_swatch_color)) ? theme.default_color : theme.key_swatch_color, n))
 
     # only consider layouts with a reasonable number of columns
     maxcols = theme.key_max_columns < 1 ? 1 : theme.key_max_columns
@@ -144,7 +144,7 @@ function render_discrete_key(labels::Vector{String}, title_ctx::Context, title_w
                     fill(theme.key_label_color))
 
                 col = compose!(context(xpos, yoff), swatches, swatch_labels)
-                if aes_color_label != nothing
+                if issomething(aes_color_label)
                     classes = [svg_color_class_from_label(aes_color_label([c])[1]) for c in clrs]
                     #class_jscalls = ["data(\"color_class\", \"$(c)\")" for c in classes]
                     compose!(col,

--- a/src/mapping.jl
+++ b/src/mapping.jl
@@ -88,7 +88,7 @@ end
 function meltdata(U::AbstractVector, colgroups_::Vector{Col.GroupedColumn})
     colgroups = Set(colgroups_)
 
-    if length(colgroups) != 1 || first(colgroups).columns!==nothing
+    if length(colgroups) != 1 || issomething(first(colgroups).columns)
         # if every column is of the same length, treat it as a matrix
         if length(Set([length(u for u in U)])) == 1
             return meltdata(cat(U..., dims=2), colgroups_)
@@ -131,7 +131,7 @@ function meltdata(U::AbstractMatrix, colgroups_::Vector{Col.GroupedColumn})
     vm = um
     grouped_columns = BitSet()
     for colgroup in colgroups
-        if colgroup.columns===nothing
+        if isnothing(colgroup.columns)
             vm *= un
             grouped_columns = copy(allcolumns)
         else
@@ -150,7 +150,7 @@ function meltdata(U::AbstractMatrix, colgroups_::Vector{Col.GroupedColumn})
     col_indicators = Array{Int}(undef, vm, length(colgroups))
     row_indicators = Array{Int}(undef, vm, length(colgroups))
 
-    colidxs = [colgroup.columns===nothing ? collect(allcolumns) : colgroup.columns
+    colidxs = [isnothing(colgroup.columns) ? collect(allcolumns) : colgroup.columns
                for colgroup in colgroups]
 
     vi = 1

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -178,7 +178,7 @@ function inherit!(a::T, b::T) where T
         aval = getfield(a, field)
         bval = getfield(b, field)
         # TODO: this is a hack to let non-default labelers overide the defaults
-        if aval === nothing || aval === string || aval == showoff
+        if isnothing(aval) || aval === string || aval == showoff
             setfield!(a, field, bval)
         elseif typeof(aval) <: Dict && typeof(bval) <: Dict
             merge!(aval, getfield(b, field))

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -18,9 +18,9 @@ include("color_misc.jl")
 iscategorical(scales::Dict{Symbol, Gadfly.ScaleElement}, var::Symbol) =
         haskey(scales, var) && isa(scales[var], DiscreteScale)
 
-function apply_scales(scales, aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
+function apply_scales(scales, aess::Vector{Gadfly.Aesthetics}, datas::Vector{Gadfly.Data})
     for scale in scales
-        apply_scale(scale, aess, datas...)
+        apply_scale(scale, aess, datas)
     end
 
     for (aes, data) in zip(aess, datas)
@@ -28,9 +28,9 @@ function apply_scales(scales, aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Dat
     end
 end
 
-function apply_scales(scales, datas::Gadfly.Data...)
+function apply_scales(scales, datas::Vector{Gadfly.Data})
     aess = Gadfly.Aesthetics[Gadfly.Aesthetics() for _ in datas]
-    apply_scales(scales, aess, datas...)
+    apply_scales(scales, aess, datas)
     aess
 end
 
@@ -177,9 +177,12 @@ alpha_continuous(; minvalue=0.0, maxvalue=1.0, labels=nothing, format=nothing, m
      ContinuousScale([:alpha], identity_transform, minvalue=minvalue, maxvalue=maxvalue,
                labels=labels, format=format, minticks=minticks, maxticks=maxticks, scalable=scalable)
 
+# Need to wrap Gadfly.Data in array for apply_scale methods
+apply_scale(scale::Gadfly.ScaleElement, aess::Vector{Gadfly.Aesthetics}, data::Gadfly.Data) =
+    apply_scale(scale, aess, Gadfly.Data[data])
 
 function apply_scale(scale::ContinuousScale,
-                     aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
+                     aess::Vector{Gadfly.Aesthetics}, datas::Vector{Gadfly.Data})
     for (aes, data) in zip(aess, datas)
         for var in scale.vars
             vals = getfield(data, var)
@@ -362,7 +365,7 @@ alpha_discrete(; labels=nothing, levels=nothing, order=nothing) =
         DiscreteScale([:linestyle], labels=labels, levels=levels, order=order)
 
 
-function apply_scale(scale::DiscreteScale, aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
+function apply_scale(scale::DiscreteScale, aess::Vector{Gadfly.Aesthetics}, datas::Vector{Gadfly.Data})
     for (aes, data) in zip(aess, datas)
         for var in scale.vars
             label_var = Symbol(var, "_label")
@@ -411,7 +414,7 @@ const color_none = NoneColorScale
 element_aesthetics(scale::NoneColorScale) = [:color]
 
 function apply_scale(scale::NoneColorScale,
-                     aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
+                     aess::Vector{Gadfly.Aesthetics}, datas::Vector{Gadfly.Data})
     for aes in aess
         aes.color = nothing
     end
@@ -429,7 +432,7 @@ const color_identity = IdentityColorScale
 element_aesthetics(scale::IdentityColorScale) = [:color]
 
 function apply_scale(scale::IdentityColorScale,
-                     aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
+                     aess::Vector{Gadfly.Aesthetics}, datas::Vector{Gadfly.Data})
     for (aes, data) in zip(aess, datas)
         data.color === nothing && continue
         aes.color = discretize_make_ia(data.color)
@@ -512,7 +515,7 @@ end
 @deprecate discrete_color_manual(colors...; levels=nothing, order=nothing) color_discrete_manual(colors...; levels=levels, order=order)
 
 function apply_scale(scale::DiscreteColorScale,
-                     aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
+                     aess::Vector{Gadfly.Aesthetics}, datas::Vector{Gadfly.Data})
     levelset = OrderedSet()
     for (aes, data) in zip(aess, datas)
         data.color === nothing && continue
@@ -620,7 +623,7 @@ const color_continuous_gradient = color_continuous  ### WHY HAVE THIS ALIAS?
 @deprecate continuous_color(;minvalue=nothing, maxvalue=nothing) color_continuous(;minvalue=nothing, maxvalue=nothing)
 
 function apply_scale(scale::ContinuousColorScale,
-                     aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
+                     aess::Vector{Gadfly.Aesthetics}, datas::Vector{Gadfly.Data})
     cdata = skipmissing(Iterators.flatten(i.color for i in datas if i.color != nothing))
     if !isempty(cdata)
       cmin, cmax = extrema(cdata)
@@ -692,7 +695,7 @@ struct LabelScale <: Gadfly.ScaleElement
 end
 
 function apply_scale(scale::LabelScale,
-                     aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
+                     aess::Vector{Gadfly.Aesthetics}, datas::Vector{Gadfly.Data})
     for (aes, data) in zip(aess, datas)
         data.label === nothing && continue
         aes.label = discretize(data.label)
@@ -732,7 +735,7 @@ end
 element_aesthetics(scale::IdentityScale) = [scale.var]
 
 function apply_scale(scale::IdentityScale,
-                     aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
+                     aess::Vector{Gadfly.Aesthetics}, datas::Vector{Gadfly.Data})
     for (aes, data) in zip(aess, datas)
         getfield(data, scale.var) === nothing && continue
         setfield!(aes, scale.var, getfield(data, scale.var))

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -17,7 +17,8 @@ using LinearAlgebra
 using Random
 
 import Gadfly: Scale, Coord, input_aesthetics, output_aesthetics,
-               default_scales, isconcrete, setfield!, discretize_make_ia, aes2str
+    default_scales, isconcrete, setfield!, discretize_make_ia, aes2str,
+    isnothing, issomething
 import KernelDensity
 # import Distributions: Uniform, Distribution, qqbuild
 import IterTools: distinct
@@ -186,7 +187,7 @@ function apply_statistic(stat::BarStatistic,
 
     iscontinuous = haskey(scales, var) && isa(scales[var], Scale.ContinuousScale)
 
-    if getfield(aes, minvar) == nothing || getfield(aes, maxvar) == nothing
+    if isnothing(getfield(aes, minvar)) || isnothing(getfield(aes, maxvar))
         minvals, maxvals = barminmax(vals, iscontinuous)
 
         setfield!(aes, minvar, minvals)
@@ -194,13 +195,13 @@ function apply_statistic(stat::BarStatistic,
     end
 
     z = zero(eltype(getfield(aes, othervar)))
-    if getfield(aes, viewminvar) == nothing && z < minimum(getfield(aes, othervar))
+    if isnothing(getfield(aes, viewminvar)) && z < minimum(getfield(aes, othervar))
         setfield!(aes, viewminvar, z)
-    elseif getfield(aes, viewmaxvar) == nothing && z > maximum(getfield(aes, othervar))
+    elseif isnothing(getfield(aes, viewmaxvar)) && z > maximum(getfield(aes, othervar))
         setfield!(aes, viewmaxvar, z)
     end
 
-    if stat.position == :stack && aes.color !== nothing
+    if stat.position == :stack && issomething(aes.color)
         groups = Dict{Any,Float64}()
         for (x, y) in zip(getfield(aes, othervar), vals)
             Gadfly.isconcrete(x) || continue
@@ -214,11 +215,11 @@ function apply_statistic(stat::BarStatistic,
 
         viewmin, viewmax = extrema(values(groups))
         aes_viewminvar = getfield(aes, viewminvar)
-        if aes_viewminvar === nothing || aes_viewminvar > viewmin
+        if isnothing(aes_viewminvar) || aes_viewminvar > viewmin
             setfield!(aes, viewminvar, viewmin)
         end
         aes_viewmaxvar = getfield(aes, viewmaxvar)
-        if aes_viewmaxvar === nothing || aes_viewmaxvar < viewmax
+        if isnothing(aes_viewmaxvar) || aes_viewmaxvar < viewmax
             setfield!(aes, viewmaxvar, viewmax)
         end
     end
@@ -249,7 +250,7 @@ function HistogramStatistic(; bincount=nothing,
                               orientation=:vertical,
                               density=false,
                               limits=NamedTuple())
-    if bincount != nothing
+    if issomething(bincount)
         HistogramStatistic(bincount, bincount, position, orientation, density, limits)
     else
         HistogramStatistic(minbincount, maxbincount, position, orientation, density, limits)
@@ -340,7 +341,7 @@ function apply_statistic(stat::HistogramStatistic,
 
     stat.density && (bincounts = bincounts ./ (sum(bincounts) * binwidth))
 
-    if aes.color === nothing
+    if isnothing(aes.color)
         T = typeof(x_min + 1*binwidth)
         setfield!(aes, othervar, Array{Float64}(undef, d))
         setfield!(aes, minvar, Array{T}(undef, d))
@@ -398,7 +399,7 @@ function apply_statistic(stat::HistogramStatistic,
         if stat.position == :stack
             viewmax = Float64(maximum(stack_height))
             aes_viewmax = getfield(aes, viewmaxvar)
-            if aes_viewmax === nothing || aes_viewmax < viewmax
+            if isnothing(aes_viewmax) || aes_viewmax < viewmax
                 setfield!(aes, viewmaxvar, viewmax)
             end
         end
@@ -406,7 +407,7 @@ function apply_statistic(stat::HistogramStatistic,
         aes.color = discretize_make_ia(colors)
     end
 
-    getfield(aes, viewminvar) === nothing && setfield!(aes, viewminvar, 0.0)
+    isnothing(getfield(aes, viewminvar)) && setfield!(aes, viewminvar, 0.0)
 
     if haskey(scales, othervar)
         data = Gadfly.Data()
@@ -417,7 +418,7 @@ function apply_statistic(stat::HistogramStatistic,
         # See issue #560. Stacked histograms on a non-linear y scale are a strange
         # thing. After some discussion, the least confusing thing is to make the stack
         # partitioned linearly. Here we make that adjustment.
-        if stat.position == :stack && aes.color != nothing
+        if stat.position == :stack && issomething(aes.color)
             # A little trickery to figure out the scale stack height.
             data = Gadfly.Data()
             setfield!(data, othervar, stack_height)
@@ -511,7 +512,7 @@ function apply_statistic(stat::DensityStatistic,
                          aes::Gadfly.Aesthetics)
     Gadfly.assert_aesthetics_defined("DensityStatistic", aes, :x)
 
-    if aes.color === nothing
+    if isnothing(aes.color)
         isa(aes.x[1], Real) || error("Kernel density estimation only works on Real types.")
 
         x_f64 = collect(Float64, aes.x)
@@ -561,12 +562,12 @@ function Histogram2DStatistic(; xbincount=nothing,
                                 ybincount=nothing,
                                 yminbincount=3,
                                 ymaxbincount=150)
-    if xbincount != nothing
+    if issomething(xbincount)
         xminbincount = xbincount
         xmaxbincount = xbincount
     end
 
-    if ybincount != nothing
+    if issomething(ybincount)
         yminbincount = ybincount
         ymaxbincount = ybincount
     end
@@ -770,7 +771,7 @@ function apply_statistic(stat::TickStatistic,
             error("TickStatistic cannot be applied to subplot coordinates.")
 
     # don't clobber existing ticks
-    getfield(aes, Symbol(stat.axis, "tick")) == nothing || return
+    isnothing(getfield(aes, Symbol(stat.axis, "tick"))) || return
 
     in_group_var = Symbol(stat.axis, "group")
     minval, maxval = nothing, nothing
@@ -781,11 +782,11 @@ function apply_statistic(stat::TickStatistic,
     for var in in_vars
         categorical && !in(var,[:x,:y]) && continue
         vals = getfield(aes, var)
-        if vals != nothing && eltype(vals) != Function
-            if minval == nothing
+        if issomething(vals) && eltype(vals) != Function
+            if isnothing(minval)
                 minval = first(vals)
             end
-            if maxval == nothing
+            if isnothing(maxval)
                 maxval = first(vals)
             end
             T = promote_type(typeof(minval), typeof(maxval))
@@ -794,14 +795,14 @@ function apply_statistic(stat::TickStatistic,
             maxval = convert(T, maxval)
 
             if stat.axis == "x"
-                dsize = aes.xsize === nothing ? [nothing] : aes.xsize
+                dsize = isnothing(aes.xsize) ? [nothing] : aes.xsize
             elseif stat.axis == "y"
-                dsize = aes.ysize === nothing ? [nothing] : aes.ysize
+                dsize = isnothing(aes.ysize) ? [nothing] : aes.ysize
             else
                 dsize = [nothing]
             end
 
-            size = aes.size === nothing ? [nothing] : aes.size
+            size = isnothing(aes.size) ? [nothing] : aes.size
 
             minval, maxval = apply_statistic_typed(minval, maxval, vals, size, dsize)
             push!(in_vals, vals)
@@ -824,17 +825,17 @@ function apply_statistic(stat::TickStatistic,
 
     # check the x/yviewmin/max pesudo-aesthetics
     if stat.axis == "x"
-        if aes.xviewmin != nothing
+        if issomething(aes.xviewmin)
             minval = min(minval, aes.xviewmin)
         end
-        if aes.xviewmax != nothing
+        if issomething(aes.xviewmax)
             maxval = max(maxval, aes.xviewmax)
         end
     elseif stat.axis == "y"
-        if aes.yviewmin != nothing
+        if issomething(aes.yviewmin)
             minval = min(minval, aes.yviewmin)
         end
-        if aes.yviewmax != nothing
+        if issomething(aes.yviewmax)
             maxval = max(maxval, aes.yviewmax)
         end
     end
@@ -843,20 +844,20 @@ function apply_statistic(stat::TickStatistic,
     strict_span = false
     if typeof(coord) == Coord.Cartesian
         if stat.axis == "x"
-            if coord.xmin !== nothing
+            if issomething(coord.xmin)
                 minval = coord.xmin
                 strict_span = true
             end
-            if coord.xmax !== nothing
+            if issomething(coord.xmax)
                 maxval = coord.xmax
                 strict_span = true
             end
         elseif stat.axis == "y"
-            if coord.ymin !== nothing
+            if issomething(coord.ymin)
                 minval = coord.ymin
                 strict_span = true
             end
-            if coord.ymax !== nothing
+            if issomething(coord.ymax)
                 maxval = coord.ymax
                 strict_span = true
             end
@@ -923,12 +924,12 @@ function apply_statistic(stat::TickStatistic,
     setfield!(aes, Symbol(stat.axis, "tickscale"), tickscale)
 
     viewmin_var = Symbol(stat.axis, "viewmin")
-    if getfield(aes, viewmin_var) === nothing || getfield(aes, viewmin_var) > viewmin
+    if isnothing(getfield(aes, viewmin_var)) || getfield(aes, viewmin_var) > viewmin
         setfield!(aes, viewmin_var, viewmin)
     end
 
     viewmax_var = Symbol(stat.axis, "viewmax")
-    if getfield(aes, viewmax_var) === nothing || getfield(aes, viewmax_var) < viewmax
+    if isnothing(getfield(aes, viewmax_var)) || getfield(aes, viewmax_var) < viewmax
         setfield!(aes, viewmax_var, viewmax)
     end
 
@@ -959,12 +960,12 @@ function minvalmaxval(minval::T, maxval::T, val, s, ds) where T
         maxval = val
     end
 
-    if s != nothing && typeof(s) <: AbstractFloat
+    if issomething(s) && typeof(s) <: AbstractFloat
         minval = min(minval, val - s)::T
         maxval = max(maxval, val + s)::T
     end
 
-    if ds != nothing
+    if issomething(ds)
         minval = min(minval, val - ds)::T
         maxval = max(maxval, val + ds)::T
     end
@@ -999,7 +1000,7 @@ function apply_statistic(stat::BoxplotStatistic,
                          coord::Gadfly.CoordinateElement,
                          aes::Gadfly.Aesthetics)
 
-    xflag = aes.x != nothing
+    xflag = issomething(aes.x)
     aes_x = (xflag ? eltype(aes.x) : Int)[]
     if xflag
         aes_x = aes.x
@@ -1007,26 +1008,26 @@ function apply_statistic(stat::BoxplotStatistic,
         aes_x = ones(Int, length(aes.y))
         aes.x_label = x -> fill("", length(x))
     end
-    colorflag = aes.color != nothing
+    colorflag = issomething(aes.color)
     aes_color =  colorflag ? aes.color : fill(nothing, length(aes_x))
                      
-    if aes.y == nothing
+    if isnothing(aes.y)
         groups = Any[]
         for (x, c) in zip(aes.x, cycle(aes_color))
             push!(groups, (x, c))
         end
 
         yviewmin, yviewmax = minimum(aes.lower_fence), maximum(aes.upper_fence)
-        if aes.outliers !== nothing
+        if issomething(aes.outliers)
             yviewmin = minimum(yviewmin, aes.outliers)
             yviewmax = maximum(yviewmax, aes.outliers)
         end
 
-        if aes.yviewmin === nothing || aes.yviewmin > yviewmin
+        if isnothing(aes.yviewmin) || aes.yviewmin > yviewmin
             aes.yviewmin = yviewmin
         end
 
-        if aes.yviewmax === nothing || aes.yviewmax < yviewmax
+        if isnothing(aes.yviewmax) || aes.yviewmax < yviewmax
             aes.yviewmax = yviewmax
         end
     else
@@ -1082,11 +1083,11 @@ function apply_statistic(stat::BoxplotStatistic,
         xviewmin = xmin - minspan / 2
         xviewmax = xmax + minspan / 2
 
-        if aes.xviewmin === nothing || aes.xviewmin > xviewmin
+        if isnothing(aes.xviewmin) || aes.xviewmin > xviewmin
             aes.xviewmin = xviewmin
         end
 
-        if aes.xviewmax === nothing || aes.xviewmax < xviewmax
+        if isnothing(aes.xviewmax) || aes.xviewmax < xviewmax
             aes.xviewmax = xviewmax
         end
     end
@@ -1150,7 +1151,7 @@ function Stat.apply_statistic(stat::SmoothStatistic,
         error("Stat.loess and Stat.lm require that x and y be bound to arrays of plain numbers.")
     end
 
-    colorflag = aes.color != nothing
+    colorflag = issomething(aes.color)
     aes_color =  colorflag ? aes.color : fill(nothing, length(aes.x))
 
     uc = unique(aes_color)
@@ -1308,18 +1309,18 @@ function apply_statistic(stat::StepStatistic,
     p = sortperm(aes.x, alg=MergeSort)
     permute!(aes.x, p)
     permute!(aes.y, p)
-    aes.group != nothing && permute!(aes.group, p)
-    aes.color != nothing && permute!(aes.color, p)
+    issomething(aes.group) && permute!(aes.group, p)
+    issomething(aes.color) && permute!(aes.color, p)
 
-    if aes.group != nothing
+    if issomething(aes.group)
         Gadfly.assert_aesthetics_equal_length("StepStatistic", aes, :x, :group)
         permute!(aes.x, p)
         permute!(aes.y, p)
         permute!(aes.group, p)
-        aes.color != nothing && permute!(aes.color, p)
+        issomething(aes.color) && permute!(aes.color, p)
     end
 
-    if aes.color != nothing
+    if issomething(aes.color)
         Gadfly.assert_aesthetics_equal_length("StepStatistic", aes, :x, :color)
         # TODO: use this when we switch to 0.4
         # sortperm!(p, aes.color, alg=MergeSort, lt=Gadfly.color_isless)
@@ -1327,13 +1328,13 @@ function apply_statistic(stat::StepStatistic,
         permute!(aes.x, p)
         permute!(aes.y, p)
         permute!(aes.color, p)
-        aes.group != nothing && permute!(aes.group, p)
+        issomething(aes.group) && permute!(aes.group, p)
     end
 
     x_step = Array{eltype(aes.x)}(undef, 0)
     y_step = Array{eltype(aes.y)}(undef, 0)
-    color_step = aes.color == nothing ? nothing : Array{eltype(aes.color)}(undef, 0)
-    group_step = aes.group == nothing ? nothing : Array{eltype(aes.group)}(undef, 0)
+    color_step = isnothing(aes.color) ? nothing : Array{eltype(aes.color)}(undef, 0)
+    group_step = isnothing(aes.group) ? nothing : Array{eltype(aes.group)}(undef, 0)
 
     i = 1
     i_offset = 1
@@ -1343,17 +1344,17 @@ function apply_statistic(stat::StepStatistic,
 
         (u > length(aes.x) || v > length(aes.y)) && break
 
-        if (aes.color != nothing &&
+        if (issomething(aes.color) &&
              (aes.color[u] != aes.color[i_offset] || aes.color[v] != aes.color[i_offset])) ||
-           (aes.group != nothing &&
+           (issomething(aes.group) &&
              (aes.group[u] != aes.color[i_offset] || aes.color[v] != aes.group[i_offset]))
             i_offset = max(u, v)
             i = 1
         else
             push!(x_step, aes.x[u])
             push!(y_step, aes.y[v])
-            aes.color != nothing && push!(color_step, aes.color[i_offset])
-            aes.group != nothing && push!(group_step, aes.group[i_offset])
+            issomething(aes.color) && push!(color_step, aes.color[i_offset])
+            issomething(aes.group) && push!(group_step, aes.group[i_offset])
             i += 1
         end
     end
@@ -1405,7 +1406,7 @@ function apply_statistic(stat::FunctionStatistic,
     end
 
     # color was bound explicitly
-    if aes.color != nothing
+    if issomething(aes.color)
         func_color = aes.color
         aes.color = Array{eltype(aes.color)}(undef, length(aes.y) * stat.num_samples)
         groups = Array{Int}(undef, length(aes.y) * stat.num_samples)
@@ -1465,15 +1466,15 @@ function apply_statistic(stat::ContourStatistic,
                          scales::Dict{Symbol, Gadfly.ScaleElement},
                          coord::Gadfly.CoordinateElement,
                          aes::Gadfly.Aesthetics)
-    xs = aes.x === nothing ? nothing : convert(Vector{Float64}, aes.x)
-    ys = aes.y === nothing ? nothing : convert(Vector{Float64}, aes.y)
+    xs = isnothing(aes.x) ? nothing : convert(Vector{Float64}, aes.x)
+    ys = isnothing(aes.y) ? nothing : convert(Vector{Float64}, aes.y)
 
     if typeof(aes.z) <: Function
-        if xs == nothing && aes.xmin != nothing && aes.xmax != nothing
+        if isnothing(xs) && issomething(aes.xmin) && issomething(aes.xmax)
             xs = range(aes.xmin[1], stop=aes.xmax[1], length=stat.samples)
         end
 
-        if ys == nothing && aes.ymin != nothing && aes.ymax != nothing
+        if isnothing(ys) && issomething(aes.ymin) && issomething(aes.ymax)
             ys = range(aes.ymin[1], stop=aes.ymax[1], length=stat.samples)
         end
 
@@ -1482,10 +1483,10 @@ function apply_statistic(stat::ContourStatistic,
     elseif typeof(aes.z) <: Matrix
         zs = convert(Matrix{Float64}, aes.z)
 
-        if xs == nothing
+        if isnothing(xs)
             xs = collect(Float64, 1:size(zs)[1])
         end
-        if ys == nothing
+        if isnothing(ys)
             ys = collect(Float64, 1:size(zs)[2])
         end
         size(zs) != (length(xs), length(ys)) &&
@@ -1634,7 +1635,7 @@ function apply_statistic(stat::ViolinStatistic,
     grouped_color = Dict{Int, Gadfly.ColorOrNothing}(1=>nothing)
     ux = unique(aes.x)
     uxflag = length(ux) < length(aes.x)
-    colorflag = aes.color != nothing
+    colorflag = issomething(aes.color)
 
     uxflag && (grouped_y = Dict(x=>aes.y[aes.x.==x] for x in ux))
 
@@ -1701,7 +1702,7 @@ function minimum_span(vars::Vector{Symbol}, aes::Gadfly.Aesthetics)
             end
         end
 
-        if span == nothing || (dataspan != nothing && dataspan < span)
+        if isnothing(span) || (issomething(dataspan) && dataspan < span)
             span = dataspan
         end
     end
@@ -1714,7 +1715,7 @@ function apply_statistic(stat::JitterStatistic,
                          coord::Gadfly.CoordinateElement,
                          aes::Gadfly.Aesthetics)
     span = minimum_span(stat.vars, aes)
-    span == nothing && return
+    isnothing(span) && return
 
     rng = MersenneTwister(stat.seed)
     for var in stat.vars
@@ -1755,7 +1756,7 @@ function apply_statistic(stat::BinMeanStatistic,
     Tx = eltype(aes.x)
     Ty = eltype(aes.y)
 
-    if aes.color === nothing
+    if isnothing(aes.color)
         (aes.x, aes.y) = mean_by_group(aes.x, aes.y, breaks)
     else
         groups = Dict()
@@ -1827,8 +1828,8 @@ function apply_statistic(stat::EnumerateStatistic,
                          scales::Dict{Symbol, Gadfly.ScaleElement},
                          coord::Gadfly.CoordinateElement,
                          aes::Gadfly.Aesthetics)
-    has_x = aes.x != nothing
-    has_y = aes.y != nothing
+    has_x = issomething(aes.x)
+    has_y = issomething(aes.y)
 
     if stat.var == :x && !has_x && has_y
         aes.x = collect(1:length(aes.y))
@@ -1869,14 +1870,14 @@ function apply_statistic(stat::VecFieldStatistic,
                          scales::Dict{Symbol, Gadfly.ScaleElement},
                          coord::Gadfly.CoordinateElement,
                          aes::Gadfly.Aesthetics)
-    xs = aes.x === nothing ? nothing : Float64.(aes.x)
-    ys = aes.y === nothing ? nothing : Float64.(aes.y)
+    xs = isnothing(aes.x) ? nothing : Float64.(aes.x)
+    ys = isnothing(aes.y) ? nothing : Float64.(aes.y)
 
     if isa(aes.z, Function)
-        if xs == nothing && aes.xmin != nothing && aes.xmax != nothing
+        if isnothing(xs) && issomething(aes.xmin) && issomething(aes.xmax)
             xs = range(aes.xmin[1], stop=aes.xmax[1], length=stat.samples)
         end
-        if ys == nothing && aes.ymin != nothing && aes.ymax != nothing
+        if isnothing(ys) && issomething(aes.ymin) && issomething(aes.ymax)
             ys = range(aes.ymin[1], stop=aes.ymax[1], length=stat.samples)
         end
 
@@ -1885,10 +1886,10 @@ function apply_statistic(stat::VecFieldStatistic,
     elseif isa(aes.z, Matrix)
         zs = Float64.(aes.z)
 
-        if xs == nothing
+        if isnothing(xs)
             xs = collect(Float64, 1:size(zs)[1])
         end
-        if ys == nothing
+        if isnothing(ys)
             ys = collect(Float64, 1:size(zs)[2])
         end
         if size(zs) != (length(xs), length(ys))
@@ -1981,8 +1982,8 @@ function apply_statistic(stat::EllipseStatistic,
     aes::Gadfly.Aesthetics)    
 
     Dat = [aes.x aes.y]
-    colorflag = aes.color != nothing
-    groupflag = aes.group != nothing
+    colorflag = issomething(aes.color)
+    groupflag = issomething(aes.group)
     aes_color = colorflag ? aes.color : fill(nothing, length(aes.x)) 
     aes_group = groupflag ? aes.group : fill(nothing, length(aes.x))
     CT, GT = eltype(aes_color), eltype(aes_group)
@@ -2053,7 +2054,7 @@ function apply_statistic(stat::DodgeStatistic,
                             coord::Gadfly.CoordinateElement,
                             aes::Gadfly.Aesthetics)
 
-    aes.color==nothing && return
+    isnothing(aes.color) && return
     nbars = length(unique(aes.color))
     othervar = (stat.axis == :x) ? :y : :x
     vals = getfield(aes, stat.axis)

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -214,7 +214,7 @@ function optimize_ticks(x_min::DateTime, x_max::DateTime; extend_ticks::Bool=fal
                     # TODO: manually setting scale with :day, :minute, etc
                 end
 
-                if scale === nothing
+                if isnothing(scale)
                     for proposed_scale in [Day(1), Hour(1), Minute(1),
                                            Second(1), Millisecond(100),
                                            Millisecond(10), Millisecond(1)]
@@ -225,7 +225,7 @@ function optimize_ticks(x_min::DateTime, x_max::DateTime; extend_ticks::Bool=fal
                     end
                 end
 
-                if scale === nothing
+                if isnothing(scale)
                     scale = Millisecond(1)
                 end
 

--- a/src/varset.jl
+++ b/src/varset.jl
@@ -45,7 +45,7 @@ macro varset(name::Symbol, table)
         push!(parameters, Expr(:kw, var, default))
         push!(inherit_parameters, Expr(:kw, var, :(b.$var)))
         if typ==:ColorOrNothing
-            push!(parsed_vars, :($(var)==nothing ? nothing : parse_colorant($(var))))
+            push!(parsed_vars, :(isnothing($(var)) ? nothing : parse_colorant($(var))))
         else
             push!(parsed_vars, :($(var)))
         end


### PR DESCRIPTION
<!-- Replace XXX with the issue number that this PR fixes, remove if there is no corresponding issue -->
Fixes #XXX

These two changes give close to a 20% speedup in time-to-first-plot in my informal bench-marking. Unfortunately, this produces different output on some of the regression suite (thus the WIP); things aren't getting drawn in the same order as before (see below). A total of 17 images are different. Don't worry; I'll figure it out.

![density2d](https://user-images.githubusercontent.com/17915621/56402513-90904300-622b-11e9-8a7b-56f5bd10fa70.png)

![density2d](https://user-images.githubusercontent.com/17915621/56402525-9dad3200-622b-11e9-9969-077c3f4d52e7.png)

The changes here are just my fumbling attempts to address the profiling in #1275. I honestly expected the first commit in this pack to have a bigger effect than it did, and I expected the nothing comparisons to be negligible when in reality they were more important than getting rid of the splatting.

# Contributor checklist:

<!-- Make sure to complete all of these that apply -->

- [ ] I've updated the documentation to reflect these changes
- [ ] I've added an entry to `NEWS.md`
- [ ] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've `squash`'ed or `fixup`'ed junk commits with git-rebase
- [ ] I've built the docs and confirmed these changes don't cause new errors


# Proposed changes

-
-
-
