### PR TITLE
Avoid deprecated msg, in DataFrames 0.19: df[col] -> df[!, col].

### DIFF
--- a/src/dataframes.jl
+++ b/src/dataframes.jl
@@ -93,7 +93,7 @@ end
 evalmapping(source::MeltedData{T}, arg::Col.GroupedColumnValue) where T<:AbstractDataFrame =
     source.melted_data[source.colmap[Col.GroupedColumn(arg.columns)]]
 
-evalmapping(source::AbstractDataFrame, arg::Symbol) = source[arg]
+evalmapping(source::AbstractDataFrame, arg::Symbol) = source[!, arg]
 evalmapping(source::AbstractDataFrame, arg::AbstractString) = evalmapping(source, Symbol(arg))
-evalmapping(source::AbstractDataFrame, arg::Integer) = source[arg]
+evalmapping(source::AbstractDataFrame, arg::Integer) = source[!, arg]
 evalmapping(source::AbstractDataFrame, arg::Expr) = with(source, arg)


### PR DESCRIPTION
In DataFrames 0.19 the access with only one parameter, the column, is
deprecated, you can use df[:,col] (to return a copy) or df[!, col] (to return a
view).

<!-- Replace XXX with the issue number that this PR fixes, remove if there is no corresponding issue -->
Fixes #1312