### PR TITLE
Fix #1330 handle closures with special scaling

### DIFF
--- a/src/scale.jl
+++ b/src/scale.jl
@@ -172,7 +172,7 @@ const slope_continuous = continuous_scale_partial([:slope], identity_transform)
     alpha_continuous[(; minvalue=0.0, maxvalue=1.0, labels=nothing,
                      format=nothing, minticks=2, maxticks=10, scalable=true)]
 
-Rescale the data values between `minvalue` and `maxvalue` to opacity (alpha) values between 0 and 1.  
+Rescale the data values between `minvalue` and `maxvalue` to opacity (alpha) values between 0 and 1.
 """
 alpha_continuous(; minvalue=0.0, maxvalue=1.0, labels=nothing, format=nothing, minticks=2, maxticks=10, scalable=true) =
      ContinuousScale([:alpha], identity_transform, minvalue=minvalue, maxvalue=maxvalue,
@@ -192,7 +192,7 @@ function apply_scale(scale::ContinuousScale,
             # special case for function arrays bound to :y
             # pass the function values through and wait for the scale to
             # be reapplied by Stat.func
-            if var == :y && eltype(vals) == Function
+            if var == :y && eltype(vals) <: Function
                 aes.y = vals
                 continue
             end
@@ -325,7 +325,7 @@ anything in the data that's not respresented in `levels` will be set to
 `missing`.  `order` is a vector of integers giving a permutation of the levels
 default order.
 
-See also [`group_discrete`](@ref), [`shape_discrete`](@ref), 
+See also [`group_discrete`](@ref), [`shape_discrete`](@ref),
 [`size_discrete`](@ref), [`linestyle_discrete`](@ref), and [`alpha_discrete`](@ref).
 """
 
@@ -479,13 +479,13 @@ Gadfly.Scale.DiscreteColorScale(Gadfly.Scale.default_discrete_colors, nothing, n
 
 julia> x.f(3)
 3-element Array{ColorTypes.Color,1}:
- LCHab{Float32}(70.0,60.0,240.0)        
- LCHab{Float32}(80.0,70.0,100.435)      
+ LCHab{Float32}(70.0,60.0,240.0)
+ LCHab{Float32}(80.0,70.0,100.435)
  LCHab{Float32}(65.8994,62.2146,353.998)
 ```
 """
 color_discrete_hue(f=default_discrete_colors;
-                   levels=nothing, order=nothing, preserve_order=true) = 
+                   levels=nothing, order=nothing, preserve_order=true) =
         DiscreteColorScale(f, levels=levels, order=order, preserve_order=preserve_order)
 
 @deprecate discrete_color_hue(; levels=nothing, order=nothing, preserve_order=true) color_discrete_hue(; levels=levels, order=order, preserve_order=preserve_order)
@@ -712,7 +712,7 @@ const label = LabelScale
     xgroup[(; labels=nothing, levels=nothing, order=nothing)]
 
 A discrete scale for use with [`Geom.subplot_grid`](@ref Gadfly.Geom.subplot_grid).
-""" 
+"""
 xgroup(; labels=nothing, levels=nothing, order=nothing) =
         DiscreteScale([:xgroup], labels=labels, levels=levels, order=order)
 

--- a/test/testscripts/function_closure_scale_plot.jl
+++ b/test/testscripts/function_closure_scale_plot.jl
@@ -1,0 +1,6 @@
+using Gadfly
+
+set_default_plot_size(6inch, 3inch)
+
+closure(a) = [x -> a[i]*x for i in 1:length(a)]
+plot(closure(1:2), 0, 2π, Scale.y_log10())


### PR DESCRIPTION
Fixes #1330
Relax constraint to subtypes of `Function` to allow closures with scaling.

# Contributor checklist:

- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests (they fail on master...)
- [x] I've `squash`'ed or `fixup`'ed junk commits with git-rebase
