### PR TITLE
update cat_aes_var!

### DIFF
--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -262,19 +262,19 @@ function cat_aes_var!(a::Dict, b::Dict)
     a
 end
 
-cat_aes_var!(a::AbstractArray{T}, b::AbstractArray{T}) where {T <: Base.Callable} = append!(a, b)
-cat_aes_var!(a::AbstractArray{T}, b::AbstractArray{U}) where {T <: Base.Callable, U <: Base.Callable} =
-        a=[promote(a..., b...)...]
+cat_aes_var!(a::AbstractVector{T}, b::AbstractVector{T}) where {T <: Base.Callable} = append!(a, b)
+cat_aes_var!(a::AbstractVector{T}, b::AbstractVector{U}) where {T <: Base.Callable, U <: Base.Callable} =
+        a = [a...,b...]
 
 # Let arrays of numbers clobber arrays of functions. This is slightly odd
 # behavior, comes up with with function statistics applied on a layer-wise
 # basis.
-cat_aes_var!(a::AbstractArray{T}, b::AbstractArray{U}) where {T <: Base.Callable, U} = b
-cat_aes_var!(a::AbstractArray{T}, b::AbstractArray{U}) where {T, U <: Base.Callable} = a
-cat_aes_var!(a::AbstractArray{T}, b::AbstractArray{T}) where {T} = append!(a, b)
+cat_aes_var!(a::AbstractVector{T}, b::AbstractVector{U}) where {T <: Base.Callable, U} = b
+cat_aes_var!(a::AbstractVector{T}, b::AbstractVector{U}) where {T, U <: Base.Callable} = a
+cat_aes_var!(a::AbstractVector{T}, b::AbstractVector{T}) where {T} = append!(a, b)
 cat_aes_var!(a, b) = a
 
-function cat_aes_var!(a::AbstractArray{T}, b::AbstractArray{U}) where {T, U}
+function cat_aes_var!(a::AbstractVector{T}, b::AbstractVector{U}) where {T, U}
     V = promote_type(T, U)
     ab = Array{V}(undef, length(a) + length(b))
     i = 1

--- a/test/testscripts/cat_aes_var.jl
+++ b/test/testscripts/cat_aes_var.jl
@@ -1,0 +1,23 @@
+
+# Issue #1228
+
+using Gadfly
+
+set_default_plot_size(6inch, 3inch)
+
+y =  [0.15, 0.038, 0.5 , 0.24, 0.32, 0.48, 0.4, 0.036, 0.97, 0.3]
+
+p1 = plot( layer(x=[5], y=[1.0], shape=[Shape.star1]),
+    layer(x=1:10, y=y, shape=[Shape.circle], alpha=[0.1]),
+    Theme(point_size=4pt, discrete_highlight_color=identity, key_position=:none) )
+
+Zi = [(x,y) for x in -5:0.5:5, y in -5:0.5:5]
+fn1(x) = x[1]*exp(-hypot(x[1]/3, x[2]/3)^2); fn2(x) = cos(hypot(x[1], x[2])/0.5)+1.0
+i, ls = -5:0.5:5, 0.2:0.2:0.8
+p2 = plot(Coord.cartesian(fixed=true),
+    layer(z=fn2.(Zi), x=i, y=i, Geom.contour(levels=[1.0]), Theme(line_style=[:dash])),
+    layer(z=fn1.(Zi), x=i, y=i, Stat.contour(levels=[-ls; ls]), Geom.polygon(fill=true)),
+    Scale.color_continuous(minvalue=-1, maxvalue=1.0), Theme(lowlight_color=identity) 
+)
+
+hstack(p1, p2)


### PR DESCRIPTION

- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

This PR:
- updates Gadfly's `cat_aes_var!` methods 
- fixes #1228

`cat_aes_var!` is called by `Gadfly.concat`, which forms the plot_aes (later used in rendering guides). In Gadfly, all aesthetics are 1d vectors, not arrays (except for `z`). 
With this PR, `z` arrays fallback on the [general `cat_aes_var!` function](https://github.com/GiovineItalia/Gadfly.jl/blob/ce69a6451e2a8fe67d983e453693aea4a4f8b34f/src/aesthetics.jl#L275).

Examples (from #1228):
```julia
p1 = plot( layer(x=[5], y=[1.0], shape=[Shape.star1]),
    layer(x=1:10, y=rand(10), Geom.point, shape=[Shape.circle], alpha=[0.1]),
    Theme(point_size=4pt, discrete_highlight_color=identity, key_position=:none) )

Zi = [(x,y) for x in -5:0.5:5, y in -5:0.5:5]
fn1(x) = x[1]*exp(-hypot(x[1]/3, x[2]/3)^2); fn2(x) = cos(hypot(x[1], x[2])/0.5)+1.0
i, ls = -5:0.5:5, 0.2:0.2:0.8
p2 = plot(Coord.cartesian(fixed=true),
    layer(z=fn2.(Zi), x=i, y=i, Geom.contour(levels=[1.0]), Theme(line_style=[:dash])),
    layer(z=fn1.(Zi), x=i, y=i, Stat.contour(levels=[-ls; ls]), Geom.polygon(fill=true)),
    Scale.color_continuous(minvalue=-1, maxvalue=1.0), Theme(lowlight_color=identity) 
)
hstack(p1, p2)
```
![iss1228](https://user-images.githubusercontent.com/18226881/67445345-55e2e980-f658-11e9-9488-b3c7f4bd6abe.png)

