### PR TITLE
Fixes #1338

### DIFF
--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -348,7 +348,7 @@ function by_xy_group(aes::T, xgroup, ygroup,
         end
 
         vals = getfield(aes, var)
-        if typeof(vals) <: AbstractArray
+        if isa(vals, AbstractArray) && length(vals)>1 
             if xgroup !== nothing && length(vals) !== length(xgroup) ||
                ygroup !== nothing && length(vals) !== length(ygroup)
                 continue

--- a/src/geom/point.jl
+++ b/src/geom/point.jl
@@ -47,7 +47,7 @@ function render(geom::PointGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
     Gadfly.assert_aesthetics_equal_length("Geom.point", aes, :x, :y)
 
     default_aes = Gadfly.Aesthetics()
-    default_aes.shape = Function[Shape.circle]
+    default_aes.shape = Function[theme.point_shapes[1]]
     default_aes.color = discretize_make_ia(RGBA{Float32}[theme.default_color])
     default_aes.size = Measure[theme.point_size]
     default_aes.alpha = [theme.alphas[1]]

--- a/test/testscripts/issue1338.jl
+++ b/test/testscripts/issue1338.jl
@@ -1,0 +1,17 @@
+using DataFrames, Gadfly
+
+set_default_plot_size(6.6inch,3.3inch)
+
+y = [0.71, 0.88, 0.97, 0.8, 0.16, 0.12, 0.52, 0.52, 0.67, 0.31]
+df = DataFrame(x=repeat(1:5,2), y=y, z=repeat(["a","b"], inner=5))
+
+stylef(shape::Function) = style(point_shapes=[shape], point_size=2mm)
+p2 = plot( layer(x=1:10, y=y, stylef(Shape.cross)),
+    layer(x=1:10, y=y.+0.3, stylef(Shape.xcross)) )
+
+p3 = plot(df, xgroup=:z, x=:x, y=:y, shape=[Shape.square], alpha=[0.1],
+    Geom.subplot_grid(Geom.point), 
+    Theme(point_size=5pt, key_position=:none, discrete_highlight_color=identity) )
+    
+hstack(p2, p3)
+   


### PR DESCRIPTION
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR:

- Fixes #1338
- Makes the default behaviour for `Geom.point` consistent with the other discrete aesthetics
- Makes the syntax e.g. `shape=x`, when length(x)==1, work with `Geom.subplot_grid`

### Examples
```julia
# p2 and p3 refer to the 2nd and 3rd plot in #1338
y = rand(10)
df = DataFrame(x=repeat(1:5,2), y=y, z=repeat(["a","b"], inner=5))
stylef(shape::Function) = style(point_shapes=[shape], point_size=2mm)

p2 = plot( layer(x=1:10, y=y, stylef(Shape.cross)),
    layer(x=1:10, y=y.+0.3, stylef(Shape.xcross)) )
p3 = plot(df, xgroup=:z, x=:x, y=:y, shape=[Shape.square], alpha=[0.1],
    Geom.subplot_grid(Geom.point), 
    Theme(point_size=5pt, key_position=:none, discrete_highlight_color=identity)
)
hstack(p2, p3)
```
![issue1338](https://user-images.githubusercontent.com/18226881/68094010-30739c80-fef0-11e9-8357-62cc4a21296c.png)
