### PR TITLE
Geom.blank

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@ This is a log of major changes in Gadfly between releases. It is not exhaustive.
 Each release typically has a number of minor bug fixes beyond what is listed here.
 
 # Version 1.x
-* Support DataFrames.jl 0.19 changes in indexing (#1318)
+ * Add `Geom.blank` (#1345)
+ * Support DataFrames.jl 0.19 changes in indexing (#1318)
 
 
 

--- a/docs/src/gallery/geometries.md
+++ b/docs/src/gallery/geometries.md
@@ -57,6 +57,15 @@ set_default_plot_size(14cm, 8cm)
 plot(dataset("lattice", "singer"), x="VoicePart", y="Height", Geom.beeswarm)
 ```
 
+## [`Geom.blank`](@ref)
+
+```@example
+using Gadfly
+set_default_plot_size(21cm, 8cm)
+p1, p2 = plot(),  plot(x=1:10, y=rand(10), Geom.blank)
+hstack(p1, p2)
+```
+
 
 ## [`Geom.boxplot`](@ref)
 

--- a/docs/src/lib/gadfly.md
+++ b/docs/src/lib/gadfly.md
@@ -5,7 +5,7 @@ Author = "Ben J. Arthur"
 # Gadfly
 
 ```@index
-Modules = [Compose, Gadfly]
+Modules = [Base, Compose, Gadfly]
 ```
 
 ```@autodocs

--- a/docs/src/man/plotting.md
+++ b/docs/src/man/plotting.md
@@ -47,6 +47,23 @@ hstack(p1,p2,p3)
 ```
 
 
+## Adding to a plot
+Another feature is that a plot can be added to incrementally, using `push!`. 
+
+```@setup 3
+using Compose, Gadfly
+set_default_plot_size(14cm, 8cm)
+```
+
+```@example 3
+p = plot(x=[0,6], y=[0,6], Geom.blank)
+push!(p, layer(x=[2,4], y=[2,4], size=[1.4142cx], color=[colorant"gold"]))
+push!(p, Coord.cartesian(fixed=true))
+push!(p, Guide.title("My Awesome Plot"))
+```
+
+
+
 ## Wide-formatted data
 
 Gadfly is designed to plot data in so-called "long form", in which data that

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -337,6 +337,12 @@ end
 include("poetry.jl")
 
 
+"""
+    push!(p::Plot, element::ElementOrFunctionsOrLayers)
+
+Add an element, function or layer to a plot. Elements include
+Coordinates, Geometries, Guides, Scales, Statistics, and Themes.
+"""
 function Base.push!(p::Plot, element::ElementOrFunctionOrLayers)
     add_plot_element!(p, element)
     return p
@@ -1102,6 +1108,15 @@ include("coord.jl")
 include("geometry.jl")
 include("guide.jl")
 include("statistics.jl")
+
+
+"""
+    plot()
+
+Blank plot.
+"""
+plot() = plot(Geom.blank())
+
 
 
 # All aesthetics must have a scale. If none is given, we use a default.

--- a/src/geom/blank.jl
+++ b/src/geom/blank.jl
@@ -1,0 +1,19 @@
+
+
+struct BlankGeometry <: Gadfly.GeometryElement
+end
+
+"""
+    Geom.blank
+
+A blank geometry is drawn, and guides maybe drawn if aesthetics are provided.
+"""
+blank = BlankGeometry
+
+element_aesthetics(::BlankGeometry) = [:x, :y, :size, :color, :shape]
+
+
+function render(geom::BlankGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
+    ctx = context()
+    return compose!(ctx, svgclass("geometry"))
+end

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -51,6 +51,7 @@ default_statistic(::Gadfly.GeometryElement) = Gadfly.Stat.identity()
 
 
 include("geom/bar.jl")
+include("geom/blank.jl")
 include("geom/boxplot.jl")
 include("geom/errorbar.jl")
 include("geom/hexbin.jl")

--- a/test/testscripts/blank.jl
+++ b/test/testscripts/blank.jl
@@ -1,0 +1,12 @@
+
+using Gadfly
+
+set_default_plot_size(21cm, 8cm)
+
+y = [0.46, 0.13, 0.4, 0.73, 0.43]
+
+p1 = plot(x=[0,10], y=[0,1], Geom.blank)
+p2 = plot()
+p3 = push!(plot(), layer(x=1:5, y=y, Geom.point))
+
+hstack(p1, p2, p3)


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR
- Adds `Geom.blank` 
- Adds `plot()` (closes #947) which is user-friendly, and allows `push!`
- Adds docstring for `push!`, plus doc examples
- Is not aimed at the case with explicit empty arrays: `x=[], y=[]` (#751), which should be handled separately

### Example
```julia
p1 = plot(x=[0,10], y=[0,1], Geom.blank)
p2 = plot()
p3 = push!(plot(), layer(x=1:5, y=rand(5), Geom.point))
hstack(p1, p2, p3)
```
![geom_blank](https://user-images.githubusercontent.com/18226881/68674674-70024e80-05aa-11ea-8837-2ec6ff513400.png)
