### PR TITLE
Improvements for Measure types in the plot_aes

### DIFF
--- a/docs/src/man/plotting.md
+++ b/docs/src/man/plotting.md
@@ -51,13 +51,13 @@ hstack(p1,p2,p3)
 Another feature is that a plot can be added to incrementally, using `push!`. 
 
 ```@setup 3
-using Compose, Gadfly
+using Gadfly
 set_default_plot_size(14cm, 8cm)
 ```
 
 ```@example 3
-p = plot(x=[0,6], y=[0,6], Geom.blank)
-push!(p, layer(x=[2,4], y=[2,4], size=[1.4142cx], color=[colorant"gold"]))
+p = plot()
+push!(p, layer(x=[2,4], y=[2,4], size=[1.4142], color=[colorant"gold"]))
 push!(p, Coord.cartesian(fixed=true))
 push!(p, Guide.title("My Awesome Plot"))
 ```

--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -1,3 +1,5 @@
+using Measures
+
 const CategoricalAesthetic =
     Union{Nothing, IndirectArray}
 
@@ -295,6 +297,19 @@ function cat_aes_var!(xs::IndirectArray{T,1}, ys::IndirectArray{S,1}) where {T, 
     return append!(IndirectArray(xs.index, convert(Array{TS},xs.values)),
                    IndirectArray(ys.index, convert(Array{TS},ys.values)))
 end
+
+
+cat_aes_var!(a::AbstractVector{T}, b::AbstractVector{U}) where {T<:Measure, U<:Measure} = [a..., b...]
+
+cat_aes_var!(a::AbstractVector{T}, b::AbstractVector{U}) where {T<:Measure, U} =
+    isabsolute(T) ? [a..., b...] : b
+
+cat_aes_var!(a::AbstractVector{T}, b::AbstractVector{U}) where {T, U<:Measure} =
+    isabsolute(U) ? a : [a..., b...]
+
+
+
+
 
 # Summarizing aesthetics
 

--- a/src/coord.jl
+++ b/src/coord.jl
@@ -19,9 +19,13 @@ struct Cartesian <: Gadfly.CoordinateElement
     aspect_ratio::Union{(Nothing), Float64}
     raster::Bool
 
-    Cartesian(xvars, yvars, xmin, xmax, ymin, ymax, xflip, yflip, fixed, aspect_ratio, raster) =
-            new(xvars, yvars, xmin, xmax, ymin, ymax, xflip, yflip, fixed,
+    function Cartesian(xvars, yvars, xmin, xmax, ymin, ymax, xflip, yflip, fixed, aspect_ratio, raster)
+        # promote() not wise here  
+        xmin, xmax = [xmin, xmax]
+        ymin, ymax = [ymin, ymax]
+        new(xvars, yvars, xmin, xmax, ymin, ymax, xflip, yflip, fixed,
                 isa(aspect_ratio, Real) ? Float64(aspect_ratio) : aspect_ratio, raster)
+    end
 end
 
 function Cartesian(

--- a/test/testscripts/measures_units.jl
+++ b/test/testscripts/measures_units.jl
@@ -1,0 +1,13 @@
+using Gadfly
+
+set_default_plot_size(6.6inch,3.3inch)
+
+# Issue #1357
+
+p1 = plot(xmin=[.25], xmax=[.75], Geom.band, color=[colorant"red"])
+p2 = plot(xmin=[.25], xmax=[.75], Geom.band, color=[colorant"red"],
+    layer(Geom.rect, xmin=[0], xmax=[1], ymin=[0], ymax=[1], color=[colorant"blue"]))
+
+
+hstack(p1, p2)
+

--- a/test/testscripts/measures_units.jl
+++ b/test/testscripts/measures_units.jl
@@ -1,13 +1,15 @@
 using Gadfly
 
-set_default_plot_size(6.6inch,3.3inch)
+set_default_plot_size(8inch,3.3inch)
 
 # Issue #1357
 
 p1 = plot(xmin=[.25], xmax=[.75], Geom.band, color=[colorant"red"])
 p2 = plot(xmin=[.25], xmax=[.75], Geom.band, color=[colorant"red"],
     layer(Geom.rect, xmin=[0], xmax=[1], ymin=[0], ymax=[1], color=[colorant"blue"]))
+p3 = plot(x=[0,10], y=[0,1], Geom.blank,
+    layer(xintercept=[1.2inch], Geom.vline(color="black")) )
 
 
-hstack(p1, p2)
+hstack(p1, p2, p3)
 


### PR DESCRIPTION
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors
- [x] Move 2 functions (currently in this PR) to Measures.jl
- [ ] I've `squash`'ed or `fixup`'ed junk commits with git-rebase

### This PR:
- Fixes #1357
- Provides better support for `Measure` types (from Measures.jl)
    (e.g. when the same aesthetic in a different layer has a different type)
- Paves the way for fixing other issues e.g. [see example 2 here](https://github.com/GiovineItalia/Gadfly.jl/pull/1356#issuecomment-559371796), which I leave to another PR

### Example
            
```julia

# Examples from #1357
p1 = plot(xmin=[.25], xmax=[.75], Geom.band, color=[colorant"red"])
p2 = plot(xmin=[.25], xmax=[.75], Geom.band, color=[colorant"red"],
 layer(Geom.rect, xmin=[0], xmax=[1], ymin=[0], ymax=[1], color=[colorant"blue"]))
p3 = plot(x=[2,4], y=[2,4], size=[1.414], color=[colorant"gold"],
    Coord.cartesian(fixed=true) )
hstack(p1, p2, p3)
```
![issue1357](https://user-images.githubusercontent.com/18226881/69913147-147c0000-1488-11ea-87fa-5a92cde8fdd7.png)

Note the y-axis on plot `p1`: the Measure units appear because those are the only units provided  (cf. plot `p2`).     



