### PR TITLE
left and right triangles

### DIFF
--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -279,4 +279,34 @@ function vline(xs::AbstractArray, ys::AbstractArray, rs::AbstractArray)
     return polygon(line_ps)
 end
 
+"""
+    ltriangle(xs, ys, rs, scalar=1)
+
+$(shape_docstr("left-pointing triangles"))
+"""
+function ltriangle(xs::AbstractArray, ys::AbstractArray, rs::AbstractArray, scalar = 1)
+    n = max(length(xs), length(ys), length(rs))
+    polys = Vector{Vector{Tuple{Measure, Measure}}}(undef, n)
+    for i in 1:n
+        x = x_measure(xs[mod1(i, length(xs))])
+        y = y_measure(ys[mod1(i, length(ys))])
+        r = rs[mod1(i, length(rs))]
+        u = scalar * r
+        v = 0.87 * r
+        polys[i] = Tuple{Measure, Measure}[(x + 0.5u, y - v), (x + 0.5u, y + v),
+        (x - u, y),(x - u, y)]
+    end
+    return polygon(polys)
+end
+
+"""
+    rtriangle(xs, ys, rs)
+
+$(shape_docstr("right-pointing triangles"))
+"""
+rtriangle(xs::AbstractArray, ys::AbstractArray, rs::AbstractArray) =
+    ltriangle(xs::AbstractArray, ys::AbstractArray, rs::AbstractArray, -1)
+
+
+
 end  # module Shape

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -81,10 +81,10 @@ $(FIELDS)
     "Maximum size of points in the point geometry.  (Measure)",
     point_size_max,        Measure,         1.8mm
 
-    "Shapes of points in the point geometry.  (Function in circle, square, diamond, cross, xcross, utriangle, dtriangle, star1, star2, hexagon, octagon, hline, vline)",
+    "Shapes of points in the point geometry.  (Function in circle, square, diamond, cross, xcross, utriangle, dtriangle, star1, star2, hexagon, octagon, hline, vline, ltriangle, rtriangle)",
     point_shapes,          Vector{Function},  [Shape.circle, Shape.square, Shape.diamond, Shape.cross, Shape.xcross,
                                                Shape.utriangle, Shape.dtriangle, Shape.star1, Shape.star2,
-                                               Shape.hexagon, Shape.octagon, Shape.hline, Shape.vline]
+                                               Shape.hexagon, Shape.octagon, Shape.hline, Shape.vline, Shape.ltriangle, Shape.rtriangle]
 
     "Width of lines in the line geometry. (Measure)",
     line_width,            Measure,         0.3mm

--- a/test/testscripts/point_shape_coord.jl
+++ b/test/testscripts/point_shape_coord.jl
@@ -3,17 +3,20 @@ using DataFrames, Gadfly
 set_default_plot_size(9inch, 3inch)
 
 shapes = [Shape.square, Shape.diamond, Shape.cross, Shape.xcross, Shape.utriangle, Shape.dtriangle, 
-    Shape.star1, Shape.star2, Shape.hexagon, Shape.octagon, Shape.hline, Shape.vline]
+    Shape.star1, Shape.star2, Shape.hexagon, Shape.octagon, Shape.hline, Shape.vline, 
+    Shape.ltriangle, Shape.rtriangle]
 
- D = DataFrame(x=[1:5; 1:4; 1:3], y=[5:-1:1; 4:-1:1; 3:-1:1], g=string.(1:12))
+D = DataFrame(x=[1:5; 1:4; 1:3; 1:2], y=[5:-1:1; 4:-1:1; 3:-1:1; 2:-1:1], g=string.(1:14))
 
 function plotf(coord::Coord.cartesian) 
     plot(D, coord,
-        layer(x=:x, y=:y, style(default_color=colorant"black", point_size=2px), order=2),
-        layer(x=:x, y=:y, shape=:g, color=:g, style(point_size=4mm, point_shapes=shapes)),
-    Theme(key_position=:none, plot_padding=[0mm], background_color="white"))
+        layer(x=:x, y=:y, Theme(default_color="black", point_size=2px)),
+        layer(x=:x, y=:y, shape=:g, color=:g, Geom.point),
+    Theme(point_shapes=shapes, key_position=:none, point_size=4mm,
+     plot_padding=[0mm], background_color="white") )
 end
 
-coords = [Coord.cartesian(ymin=0, ymax=6), Coord.cartesian(xflip=true, ymin=0, ymax=6), Coord.cartesian(yflip=true, ymin=0, ymax=6)]
+coords = [Coord.cartesian(xflip=xf, yflip=yf, xmin=0, xmax=6, ymin=0, ymax=6) 
+    for (xf, yf) in zip([false, true, false], [false, false, true]) ]
 plots = plotf.(coords)
 hstack(plots...)


### PR DESCRIPTION

- [x] I've updated the documentation to reflect these changes
- [x] I've added and/or updated the unit tests
- [ ] I've run the regression tests
- [ ] I've `squash`'ed or `fixup`'ed junk commits with git-rebase
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR:
- adds left and right triangles

### Example
```julia
shapes = [Shape.ltriangle; Shape.rtriangle; Theme().point_shapes]
D = DataFrame(x=repeat([1:5;], outer=3), y=repeat([3,2,1], inner=5), g=string.(1:15))

coord = Coord.cartesian(xmin=0, ymin=0, xmax=6, ymax=4)
p = plot(D, coord, 
    layer(x=:x, y=:y, Geom.point, Theme(default_color="black", point_size=2px)),
    layer(x=:x, y=:y, Geom.point, shape=:g, color=:g),
    Theme(point_shapes=shapes, key_position=:none, point_size=12pt, 
        plot_padding=[0mm], background_color="white")
)

```
![Shape02a](https://user-images.githubusercontent.com/18226881/71038630-5ab6ac00-2176-11ea-8caf-17520834c4c4.png)

