### PR TITLE
Revert "CompatHelper: bump compat for "Colors" to "0.11""

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 Cairo = "0.7, 0.8"
 CategoricalArrays = "0.5, 0.6, 0.7"
-Colors = "0.9, 0.11"
+Colors = "0.9"
 Compose = "0.7"
 Contour = "0.5"
 CoupledFields = "0.1"


### PR DESCRIPTION
Reverts GiovineItalia/Gadfly.jl#1369 since the tests there were using Colors v0.9.6