### PR TITLE
Size revamp 1: Scale.size_discrete2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,20 +3,21 @@ This is a log of major changes in Gadfly between releases. It is not exhaustive.
 Each release typically has a number of minor bug fixes beyond what is listed here.
 
 # Version 1.x
+
+ * Add `Scale.size_discrete2` (#1376)
  * Add `Geom.blank` (#1345)
  * Support DataFrames.jl 0.19 changes in indexing (#1318)
  * Add `Geom.hband` and `Geom.vband` geometries (#1264)
  * Allow elements of type `Measure` to pass through `coord.jl` and `statistics.jl` (#1264)
 
 
-
 # Version 1.1.0
+ * Support AbstractVectors everywhere (e.g. `Guide.xticks(ticks=1:10)`) (#1295)
  * Add `alpha` aesthetic, `Scale.alpha_continuous` and `Scale.alpha_discrete` (#1252)
  * Add `limits=(min= , max= )` to `Stat.histogram` (#1249)
  * Add dodged boxplots (#1246)
  * Add `Stat.dodge` (#1240)
  * `Stat.smooth(method=:lm)` confidence bands (#1231)
- * Support AbstractVectors everywhere (e.g. `Guide.xticks(ticks=1:10)`) (#1293)
 
 # Version 0.9.0
  * conditionally depend on DataFrames (#1204)

--- a/docs/src/gallery/scales.md
+++ b/docs/src/gallery/scales.md
@@ -182,6 +182,26 @@ tipsm = by(tips, [:Day, :Sex], :TotalBill=>mean, :Tip=>mean)
 )
 ```
 
+## [`Scale.size_discrete2`](@ref)
+
+```@example
+using Compose, Gadfly, RDatasets
+set_default_plot_size(14cm, 8cm)
+
+Titanic = dataset("datasets", "Titanic")
+Class =  by(Titanic, :Class, :Freq=>sum)
+Titanic = join(Titanic[Titanic.Survived.=="Yes",:], Class, on=:Class)
+Titanic.prcnt = 100*Titanic.Freq./Titanic.Freq_sum
+sizemap = n->range(4pt, 12pt, length=n)
+
+plot(Titanic, Scale.x_log10,  Scale.y_log10,
+    x=:Freq, y=:prcnt, size=:Class, color=:Age, shape=:Sex,    
+    Scale.size_discrete2(sizemap, levels=["1st","2nd","3rd","Crew"]),
+    Guide.colorkey(pos=[0.1, -0.3h]), Guide.shapekey(pos=[0.5, -0.3h]),
+    Guide.ylabel("% of Passenger Class"),
+ Theme(discrete_highlight_color=identity, alphas=[0.1], key_swatch_color="grey")
+)
+```
 
 ## [`Scale.x_continuous`](@ref), [`Scale.y_continuous`](@ref)
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -214,7 +214,8 @@ For some discrete scales, there is a corresponding palette in `Theme()`.
 | `y` | `y_discrete` | `yticks` |  |
 | `color` | `color_discrete` | `colorkey` |  |
 | `shape` | `shape_discrete` | `shapekey` | `point_shapes` |
-| `size` | `size_discrete` | sizekey (tbd) | (tbd) |
+| `size` | `size_discrete` | sizekey (tbd) | `point_size_min`, `point_size_max` |
+|         | `size_discrete2`|               |  `discrete_sizemap` |
 | `linestyle` | `linestyle_discrete` | linekey (tbd) | `line_style`  |
 | `alpha`  | `alpha_discrete` | alphakey (tbd) | `alphas`  |
 | `group`  | `group_discrete` |  |  |

--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -63,7 +63,9 @@ const NumericalOrCategoricalAesthetic =
     color_key_continuous, Maybe(Bool)
     color_function,       Maybe(Function)
     titles,               Maybe(Dict{Symbol, AbstractString})
-    shape_key_title,    Maybe(AbstractString)
+    shape_key_title,      Maybe(AbstractString)
+    size_key_title,       Maybe(AbstractString)
+    size_key_vals,        Maybe(AbstractDict)
 
     # mark some ticks as initially invisible
     xtickvisible,         Maybe(Vector{Bool})
@@ -88,6 +90,7 @@ const NumericalOrCategoricalAesthetic =
     xgroup_label, Function, showoff
     ygroup_label, Function, showoff
     shape_label, Function, showoff
+    size_label,   Function, showoff
 
     # pseudo-aesthetics
     pad_categorical_x, Union{Missing,Bool}, missing

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -771,4 +771,8 @@ shape_identity() = IdentityScale(:shape)
 """
 size_identity() = IdentityScale(:size)
 
+
+include("scale/scales.jl")
+
+
 end # module Scale

--- a/src/scale/scales.jl
+++ b/src/scale/scales.jl
@@ -1,0 +1,69 @@
+
+
+using Measures
+
+# 1 function to be moved to Measures.jl
+Base.convert(::Type{T} , x::Measure) where T<:Real  = T(x.value)
+
+
+struct DiscreteSizeScale <: Gadfly.ScaleElement
+    f::Function
+    levels::Union{Nothing, AbstractVector}
+    order::Union{Nothing, AbstractVector}
+    preserve_order::Bool
+end 
+DiscreteSizeScale(f; levels=nothing, order=nothing, preserve_order=true) =
+        DiscreteSizeScale(f, levels, order, preserve_order)
+
+element_aesthetics(scale::DiscreteSizeScale) = [:size]
+
+default_discrete_sizes(n::Int) = range(0.45mm, 1.8mm, length=n)
+
+"""
+    size_discrete2(f=default_discrete_sizes; 
+                    levels=nothing, order=nothing, preserve_order=true)
+
+A discrete size scale that maps the categorical values in the `size`
+aesthetic to x-axis units or `Measure` units (from Measures.jl).  `f` is a function that produces a vector of size units.
+`levels` are the categorical levels, and level order will be respected.  `order` is
+a vector of integers giving a permutation of the levels default order.  If
+`preserve_order` is `true` levels are ordered as they appear in the data.
+"""
+size_discrete2(f::Function=Gadfly.current_theme().discrete_sizemap; levels=nothing, order=nothing, preserve_order=true) =
+        DiscreteSizeScale(f, levels, order, preserve_order)
+
+
+function Scale.apply_scale(scale::DiscreteSizeScale, aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
+
+    d = []
+    for (aes, data) in zip(aess, datas)
+        data.size === nothing && continue
+        append!(d, skipmissing(data.size))
+    end
+    levelset = unique(d)
+
+    if scale.levels == nothing
+        scale_levels = [levelset...]
+        scale.preserve_order || sort!(scale_levels)
+    else
+        scale_levels = scale.levels
+    end
+    scale.order == nothing || permute!(scale_levels, scale.order)
+
+    sizes = scale.f(length(scale_levels))
+
+    size_map = Dict(s=>string(label) for (s, label) in zip(sizes, scale_levels))
+    labeler(xs) = [size_map[x] for x in xs]
+    key_vals = OrderedDict(s=>i for (i,s) in enumerate(sizes))
+
+    for (aes, data) in zip(aess, datas)
+        data.size === nothing && continue
+        ds = discretize([d for d in skipmissing(data.size)], scale_levels)
+        vals = sizes[ds.index]
+        aes.size = discretize_make_ia(vals, sizes)
+        aes.size_label = labeler
+        aes.size_key_vals = key_vals
+    end
+end
+
+

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -76,10 +76,17 @@ $(FIELDS)
 
     "Size of points in the point, boxplot, and beeswarm geometries.  (Measure)",
     point_size,            Measure,         0.9mm
+
     "Minimum size of points in the point geometry.  (Measure)",
-    point_size_min,        Measure,         0.45mm
+    point_size_min,        Measure,         0.45mm,
+    "point_size_{min,max} to be deprecated. Instead try the new `Scale.size_discrete2` and/or with `style(discrete_sizemap)`"
+
     "Maximum size of points in the point geometry.  (Measure)",
-    point_size_max,        Measure,         1.8mm
+    point_size_max,        Measure,         1.8mm,
+    "point_size_{min,max} to be deprecated. Instead try the new `Scale.size_discrete2` and/or with `style(discrete_sizemap)`"
+
+    "The function `f` in  [`Scale.size_discrete2`](@ref).",
+    discrete_sizemap,      Function,        Scale.default_discrete_sizes
 
     "Shapes of points in the point geometry.  (Function in circle, square, diamond, cross, xcross, utriangle, dtriangle, star1, star2, hexagon, octagon, hline, vline, ltriangle, rtriangle)",
     point_shapes,          Vector{Function},  [Shape.circle, Shape.square, Shape.diamond, Shape.cross, Shape.xcross,

--- a/test/testscripts/point_size_categorical.jl
+++ b/test/testscripts/point_size_categorical.jl
@@ -1,5 +1,9 @@
 using Gadfly
 
-set_default_plot_size(6inch, 6inch)
+set_default_plot_size(6inch, 3inch)
 
-plot(x=rand(100), y=rand(100), size=rand(["foo","bar","pooh"], 100), Geom.point)
+x, y, size = rand(10), rand(10), rand(["foo","bar","pooh"], 10)
+p1 = plot(x=x, y=y, size=size, Geom.point)
+p2 = plot(x=x, y=y, size=size, Geom.point, Scale.size_discrete2)
+
+hstack(p1, p2)


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR

- First in a set of 3 PRs. This PR adds `Scale.size_discrete2` in the style of `Scale.color_discrete`. <br/> `Scale.size_discrete` can be switched to the new function e.g. in Gadfly 2.0. Until then, `Scale.size_discrete2` can be used.
- `Scale.size_discrete2(f=default_discrete_sizes)`, `f` is a function which maps from categorical values to `Measure` units, and allows arbitrary mappings.
- `default_discrete_sizes` has the same range as currently provided by `Theme(point_size_min, point_size_max)`
- `Theme(discrete_sizemap=default_discrete_sizes)` replaces `Theme(point_size_min, point_size_max)`, which can be deprecated.
- The 3 PRs will contain some functions to be moved to Measures.jl, but I won't do that until the third PR.

### Example 

This PR fixes the problem mentioned in #1358 with [plot p2](https://github.com/GiovineItalia/Gadfly.jl/pull/1358#issuecomment-565781720). Example:
```
y = rand(5)
pcurrent = plot(x=1:5, y=y, size=["C", "A", "A", "B", "C"],
     Theme(point_size_min=4pt, point_size_max=16pt) )
     
pnew = plot(x=1:5, y=y, size=["C", "A", "A", "B", "C"], 
    Scale.size_discrete2(n->range(4pt, 16pt, length=n)) )
    
hstack(pcurrent, pnew)
```
![Size02a](https://user-images.githubusercontent.com/18226881/71537125-99651700-296b-11ea-9653-d65c0adf461f.png)
In `pcurrent`, the y-axis is expanded by ±3 because `Scale.size_discrete` maps `size` to Integers (1:3). The mapping of the size aesthetic to size units needs to happen earlier, as in `pnew`, with `Scale.size_discrete2`

