### PR TITLE
Fix typo (Geo.title --> Guide.title) 

### DIFF
--- a/src/guide.jl
+++ b/src/guide.jl
@@ -1035,7 +1035,7 @@ struct Title <: Gadfly.GuideElement
 end
 
 """
-    Geom.title(title)
+    Guide.title(title)
 
 Set the plot title.
 """


### PR DESCRIPTION
<!-- Replace XXX with the issue number that this PR fixes, remove if there is no corresponding issue -->
Fixes #1341 

# Contributor checklist:

<!-- Make sure to complete all of these that apply -->

- [x] I've built the docs and confirmed these changes don't cause new errors


# Proposed changes

- Change Geo.title to Guide.title
