### PR TITLE
fix DataFrames deprecation warnings

### DIFF
--- a/src/dataframes.jl
+++ b/src/dataframes.jl
@@ -18,7 +18,7 @@ function meltdata(U::AbstractDataFrame, colgroups::Vector{Col.GroupedColumn})
     vnames = Symbol[]
     colmap = Dict{Any, Int}()
 
-    eltypd = Dict(k=>v for (k,v) in zip(names(U), eltypes(U)))
+    eltypd = Dict(k=>v for (k,v) in zip(names(U), eltype.(eachcol(U))))
     # allocate vectors for grouped columns
     for (j, (colgroup, colidx)) in enumerate(zip(colgroups, colidxs))
         eltyp = promote_type(getindex.([eltypd], colidx)...)

--- a/test/testscripts/issue975.jl
+++ b/test/testscripts/issue975.jl
@@ -12,8 +12,10 @@ t1 = Date("2001-01-15"):Dates.Month(1):Date("2016-12-31")
 t2 = DateTime("2001-01-15"):Dates.Month(1):DateTime("2016-12-31")
 t = Float64.(Dates.value.(t1))
 n = length(t)
-D = DataFrame(t1=t1, t2=t2, cycle = 5*sin.(t*2π/365.25)+randn(n), trend = 0.1*[1.0:n;].+2*randn(n))
-Dl = melt(D,[:t1,:t2])
+D = DataFrame(t1=t1, t2=t2,
+              cycle = 5*sin.(t*2π/365.25)+randn(n),
+              trend = 0.1*[1.0:n;].+2*randn(n))
+Dl = stack(D, setdiff(names(D), [:t1,:t2]))
 
 plot(D,
     x=:t1, y=:trend, Geom.point,

--- a/test/testscripts/subplot_grid.jl
+++ b/test/testscripts/subplot_grid.jl
@@ -5,7 +5,7 @@ set_default_plot_size(10inch, 10inch)
 barley = dataset("lattice", "barley")
 levels!(barley.Year, ["1931", "1932"])
 
-idx = [startswith(x,"No.") for x in barley.Variety]
+idx = [startswith(String(x),"No.") for x in barley.Variety]
 plot(barley[idx,:],
      xgroup="Variety", ygroup="Site", x="Year", y="Yield",
      Geom.subplot_grid(Geom.line, Geom.point))

--- a/test/testscripts/subplot_grid_free_axis.jl
+++ b/test/testscripts/subplot_grid_free_axis.jl
@@ -5,7 +5,7 @@ set_default_plot_size(10inch, 10inch)
 barley = dataset("lattice", "barley")
 levels!(barley.Year, ["1931", "1932"])
 
-idx = [startswith(x,"No.") for x in barley.Variety]
+idx = [startswith(String(x),"No.") for x in barley.Variety]
 plot(barley[idx,:],
      xgroup="Variety", ygroup="Site", x="Year", y="Yield",
      Geom.subplot_grid(Geom.line, Geom.point,


### PR DESCRIPTION
`Not` was introduced in DataFrames 0.19, so all prior versions are incompatible.

should probably wait to merge this until after the Colors issue as been resolved and a release tagged with it.