### PR TITLE
Size revamp3: ContinuousSizeScale

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ Each release typically has a number of minor bug fixes beyond what is listed her
 
 # Version 1.x
 
+ * Add `Scale.size_radius` and `Scale.size_area` (#1386)
  * Add `Guide.sizekey` (#1379)
  * Add `Scale.size_discrete2` (#1376)
  * Add `Geom.blank` (#1345)

--- a/docs/src/gallery/scales.md
+++ b/docs/src/gallery/scales.md
@@ -182,6 +182,28 @@ tipsm = by(tips, [:Day, :Sex], :TotalBill=>mean, :Tip=>mean)
 )
 ```
 
+## [`Scale.size_radius`](@ref), [`Scale.size_area`](@ref)
+
+```@example
+using Gadfly, RDatasets
+set_default_plot_size(21cm, 8cm)
+aq = dropmissing(dataset("datasets","airquality"))
+aq = filter(x-> 7≤x.Month≤9, aq)
+
+sizemap(p::Float64; min=0.75mm, max=3mm) = min + p*(max-min)
+labels = ["July", "August", "September"]
+coord = Coord.cartesian(xmin=0, xmax=32, ymin=0, ymax=160)
+plot(aq, x=:Day, y=:Ozone, color=:Month, size=:Wind,
+    coord, Scale.color_discrete,
+    Guide.colorkey(title="", labels=labels, pos=[2,240]),
+    Scale.size_area(sizemap, minvalue=4, maxvalue=16), 
+    Guide.sizekey(title="Wind (mph)"), Guide.xlabel("Day of Month"),
+    Theme(key_swatch_shape=Shape.circle, key_swatch_color="gray",
+     discrete_highlight_color=identity, alphas=[0.5])
+)
+```
+
+
 ## [`Scale.size_discrete2`](@ref)
 
 ```@example

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -162,17 +162,18 @@ colorspaces (LUV/LCHuv or LAB/LCHab), though it supports RGB, HSV, HLS, XYZ, and
 converts arbitrarily between these. Of course, CSS/X11 named colors work too:
 "old lace", anyone?
 
-All aesthetics (e.g. `x`, `y`, `color`) have a Scale e.g. `Scale.x_continuous()` and some have a Guide e.g. `Guide.xticks()`.  [Scales](@ref) can be continuous or discrete.
+All aesthetics (e.g. `x`, `y`, `color`) have a Scale e.g. `Scale.x_continuous()` and some have a Guide e.g. `Guide.xticks()`.  [Scales](@ref) can be continuous or discrete. Some Scales also have a corresponding palette in `Theme()`.
 
 ## Continuous Scales
 
-| Aesthetic | Scale. | Guide. |
-|-----------|------------------|-------|
-| `x` | `x_continuous` | `xticks` |
-| `y` | `y_continuous` | `yticks` |
-| `color` | `color_continuous` | `colorkey` |
-| `size`  | `size_continuous`  | sizekey (tbd)  |
-| `alpha` | `alpha_continuous` | alphakey (tbd) |
+| Aesthetic | Scale. | Guide. | Theme palette |
+|-----------|------------------|-------|----------|
+| `x` | `x_continuous` | `xticks` |           |
+| `y` | `y_continuous` | `yticks` |           |
+| `color` | `color_continuous` | `colorkey` |  (tbd)   |
+| `size`  | `size_continuous`  | ---  | `point_size_min`, `point_size_max` |
+|         | `size_radius`      | `sizekey` | `continuous_sizemap` |          
+| `alpha` | `alpha_continuous` | alphakey (tbd) |   |
 
 e.g. `Scale.x_continuous(format= , minvalue= , maxvalue= )`\
 `format` can be: `:plain`, `:scientific`, `:engineering`, or `:auto`.
@@ -188,7 +189,8 @@ p2 = plot(mammals, x=:Body, y=:Brain, label=:Mammal, Geom.point, Geom.label,
 hstack(p1, p2)
 ```
 
-Scale transformations include: `_sqrt`, `_log`, `_log2`, `_log10`, `_asinh`.  
+Scale transformations include: `_sqrt`, `_log`, `_log2`, `_log10`, `_asinh` for the `x`, `y`, `color` aesthetics,
+and `_area` for the `size` aesthetic.
  
 ```@example 1
 using Printf
@@ -206,13 +208,11 @@ hstack(p3, p4)
 
 ## Discrete Scales
 
-For some discrete scales, there is a corresponding palette in `Theme()`.
-
 | Aesthetic | Scale. | Guide. | Theme palette |
 |-----------|------------------|-------|-----------------|
 | `x` | `x_discrete` | `xticks` |  |
 | `y` | `y_discrete` | `yticks` |  |
-| `color` | `color_discrete` | `colorkey` |  |
+| `color` | `color_discrete` | `colorkey` | (tbd) |
 | `shape` | `shape_discrete` | `shapekey` | `point_shapes` |
 | `size` | `size_discrete` | --- | `point_size_min`, `point_size_max` |
 |         | `size_discrete2`| `sizekey` |  `discrete_sizemap` |

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -11,7 +11,7 @@ using Printf
 using Base.Iterators
 
 import Gadfly: element_aesthetics, isconcrete, concrete_length, discretize_make_ia,
-    aes2str, valid_aesthetics
+    aes2str, valid_aesthetics, Maybe
 import Distributions: Distribution
 
 include("color_misc.jl")
@@ -159,6 +159,8 @@ end
 """
     size_continuous[(; minvalue=nothing, maxvalue=nothing, labels=nothing,
                      format=nothing, minticks=2, maxticks=10, scalable=true)]
+
+To be updated in Gadfly 2.0. Now try out the new [`Scale.size_radius`](@ref) and [`Scale.size_area`](@ref).
 """
 const size_continuous = continuous_scale_partial([:size], identity_transform)
 

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -88,6 +88,9 @@ $(FIELDS)
     "The function `f` in  [`Scale.size_discrete2`](@ref).",
     discrete_sizemap,      Function,        Scale.default_discrete_sizes
 
+    "The function `f` in  [`Scale.size_radius`](@ref) and [`Scale.size_area`](@ref).",
+    continuous_sizemap,      Function,        Scale.default_continuous_sizes
+
     "Shapes of points in the point geometry.  (Function in circle, square, diamond, cross, xcross, utriangle, dtriangle, star1, star2, hexagon, octagon, hline, vline, ltriangle, rtriangle)",
     point_shapes,          Vector{Function},  [Shape.circle, Shape.square, Shape.diamond, Shape.cross, Shape.xcross,
                                                Shape.utriangle, Shape.dtriangle, Shape.star1, Shape.star2,

--- a/test/testscripts/point_size_numerical.jl
+++ b/test/testscripts/point_size_numerical.jl
@@ -1,5 +1,14 @@
 using Gadfly
 
-set_default_plot_size(6inch, 6inch)
+set_default_plot_size(9inch, 3inch)
 
-plot(x=rand(100), y=rand(100), size=rand(1:8, 100)./100, Geom.point)
+y, size = [0.55, 0.7, 0.9, 0.99, 0.9], [0.4, 0.5, 0.6, 0.68, 0.63]
+juliaclrs = Gadfly.parse_colorant(["forestgreen", "brown3", "mediumorchid"])
+theme = Theme(key_swatch_shape=Shape.circle, alphas=[0.1], discrete_highlight_color=identity)
+
+p1 = plot(x=[2,1.13,2.87], y=[3,1.5,1.5], size=[0.75], alpha=[0.8],
+    color=juliaclrs, Coord.cartesian(fixed=true))
+p2 = plot(x=1:5, y=y, size=10^5*size, Scale.size_radius(maxvalue=10^5), theme)
+p3 = plot(x=1:5, y=y, size=10^5*size, Scale.size_area(maxvalue=10^5), theme)
+
+hstack(p1, p2, p3)


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR

- the third PR in a set of 3 (#1376, #1379)
- adds `Scale.size_radius`. This should become the default `Scale.size_continuous` in Gadfly 2.0 (`Scale.size_radius` can also be kept as an alias)
- adds `Scale.size_area`

#### Design
There are three possible types of continuous sizes:
- sizes in plot units e.g. `size=[s]`, where `s` is in x,y units  
- sizes in Measure units e.g. `size=[xmm]` i.e. absolute size (these are deferred to `Scale.size_identity`)
- Real numbers where `-∞ < s < ∞` are mapped to absolute sizes

`Scale.size_radius` and `Scale.size_area` have a `default_continuous_sizes(p)` function where `0≤p≤1`. This maps proportions to absolute sizes (the default sizes are 0mm-2mm).
If `maxvalue` is specified, the continuous sizes are converted to a proportion (between `minvalue` and `maxvalue`), and then mapped to absolute sizes using the function `f(p)`.


### Examples


```julia
theme = Theme(key_swatch_shape=Shape.circle, alphas=[0.1],
  discrete_highlight_color=identity)

y, size = [0.55, 0.7, 0.9, 0.99, 0.9], [0.4, 0.5, 0.6, 0.68, 0.63]
juliaclrs = Gadfly.parse_colorant(["forestgreen", "brown3", "mediumorchid"])

p1 = plot(x=[2,1.13,2.87], y=[3,1.5,1.5], size=[0.75],
    Scale.size_radius, color=juliaclrs, Coord.cartesian(fixed=true),
    alpha=[0.8], Guide.title("size=[0.75]"))
p2 = plot(x=[2,4], y=[2,4], size=[20pt], Guide.title("size=[20pt]"))
p3 = plot(x=1:5, y=y, size=10^5*size, Scale.size_radius(maxvalue=10^5),
     Guide.title("size=10⁵⋅rand(5)"), theme)
p4 = plot(x=1:5, y=y, size=10^5*size, Scale.size_area(maxvalue=10^5),
     Guide.title("size=10⁵⋅rand(5)"), theme)
gridstack([p1 p2; p3 p4]))
```
![Size01a](https://user-images.githubusercontent.com/18226881/72677623-8c62c000-3af2-11ea-8ee1-04f73faabaad.png)

Note plot `p3` and `p4` use `Scale.size_radius` and `Scale.size_area` respectively. 

Wrt the `size` aesthetic, the only outstanding issue is to get the axis scales to take into account the absolute sizes when calculating the axis limits  e.g., in plot `p2` above. This will be done in a future PR (see #1385)
