### PR TITLE
Support explicit empty arrays

### DIFF
--- a/src/coord.jl
+++ b/src/coord.jl
@@ -91,7 +91,7 @@ function first_concrete_aesthetic_value(aess::Vector{Gadfly.Aesthetics}, vars::V
         end
     end
 
-    return nothing
+    return missing
 end
 
 
@@ -156,7 +156,7 @@ function apply_coordinate(coord::Cartesian, aess::Vector{Gadfly.Aesthetics},
 
     xmin = xmax = first_concrete_aesthetic_value(aess, coord.xvars)
 
-    if xmin != nothing
+    if !ismissing(xmin)
         for var in coord.xvars
             for aes in aess
                 vals = getfield(aes, var)
@@ -172,7 +172,7 @@ function apply_coordinate(coord::Cartesian, aess::Vector{Gadfly.Aesthetics},
     end
 
     ymin = ymax = first_concrete_aesthetic_value(aess, coord.yvars)
-    if ymin != nothing
+    if !ismissing(ymin)
         for var in coord.yvars
             for aes in aess
                 vals = getfield(aes, var)
@@ -216,10 +216,10 @@ function apply_coordinate(coord::Cartesian, aess::Vector{Gadfly.Aesthetics},
         end
     end
 
-    xmax = xviewmax === nothing ? xmax : max(xmax, xviewmax)
-    xmin = xviewmin === nothing ? xmin : min(xmin, xviewmin)
-    ymax = yviewmax === nothing ? ymax : max(ymax, yviewmax)
-    ymin = yviewmin === nothing ? ymin : min(ymin, yviewmin)
+    xmax = xviewmax === nothing ? xmax : maximum(skipmissing([xmax; xviewmax]))
+    xmin = xviewmin === nothing ? xmin : minimum(skipmissing([xmin; xviewmin]))
+    ymax = yviewmax === nothing ? ymax : maximum(skipmissing([ymax; yviewmax]))
+    ymin = yviewmin === nothing ? ymin : minimum(skipmissing([ymin; yviewmin]))
 
     # Hard limits set in Coord should override everything else
     xmin = coord.xmin === nothing ? xmin : coord.xmin
@@ -227,12 +227,12 @@ function apply_coordinate(coord::Cartesian, aess::Vector{Gadfly.Aesthetics},
     ymin = coord.ymin === nothing ? ymin : coord.ymin
     ymax = coord.ymax === nothing ? ymax : coord.ymax
 
-    if xmin === nothing || isa(xmin, Measure) || !isfinite(xmin)
+    if ismissing(xmin) || isa(xmin, Measure) || !isfinite(xmin)
         xmin = 0.0
         xmax = 1.0
     end
 
-    if ymin === nothing || isa(ymin, Measure) || !isfinite(ymin)
+    if ismissing(ymin) || isa(ymin, Measure) || !isfinite(ymin)
         ymin = 0.0
         ymax = 1.0
     end

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -830,7 +830,7 @@ function apply_statistic(stat::TickStatistic,
     for var in in_vars
         categorical && !in(var,[:x,:y]) && continue
         vals = getfield(aes, var)
-        if vals != nothing && eltype(vals) != Function
+        if vals≠nothing && !isempty(vals) && eltype(vals)≠Function
             vv = [vals; minval; maxval]
             if in(var, [:x, :y])
                 sizeflag && (vv = vec([x+s*d for (x, d) in cyclezip(vals, size), s in [-1.0, 1.0]]))
@@ -848,14 +848,14 @@ function apply_statistic(stat::TickStatistic,
         end
     end
 
-    isempty(in_vals) && return
+    isempty(in_vals) && stat.ticks==:auto && return
 
     in_vals = Iterators.flatten(in_vals)
 
     # consider forced tick marks
     if stat.ticks != :auto
-        minval = min(minval, minimum(stat.ticks))
-        maxval = max(maxval, maximum(stat.ticks))
+        minval = minimum(skipmissing([minval;stat.ticks]))
+        maxval = maximum(skipmissing([maxval;stat.ticks]))
     end
 
     # TODO: handle the outliers aesthetic

--- a/test/testscripts/issue751.jl
+++ b/test/testscripts/issue751.jl
@@ -1,0 +1,12 @@
+using Gadfly
+
+set_default_plot_size(6.6inch, 3.3inch)
+
+p1 = plot(x=[], y=[], Geom.point)
+p2 = plot(x=[], y=[], Geom.line,
+    Guide.xticks(ticks=[0,10]), Guide.yticks(ticks=[0,10])
+)
+
+hstack(p1,p2)
+
+


### PR DESCRIPTION
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR
- Fixes #751
- Adds support for explicit empty arrays

### Example
```julia
p1 = plot(x=[], y=[], Geom.point)
p2 = plot(x=[], y=[], Geom.line, Guide.xticks(ticks=[0,10]), Guide.yticks(ticks=[0,10]) )
hstack(p1, p2)
```
![issue751](https://user-images.githubusercontent.com/18226881/73535991-0000b780-4479-11ea-9c26-d40b15f4511b.png)
