### PR TITLE
Theme grid order and panel line width

### DIFF
--- a/src/guide.jl
+++ b/src/guide.jl
@@ -147,6 +147,7 @@ function render(guide::PanelBackground, theme::Gadfly.Theme,
                     svgclass("guide background"),
                     stroke(theme.panel_stroke),
                     fill(theme.panel_fill),
+                    linewidth(theme.panel_line_width),
                     svgattribute("pointer-events", "visible"))
 
     return [PositionedGuide([back], 0, under_guide_position)]
@@ -625,9 +626,9 @@ function render(guide::XTicks, theme::Gadfly.Theme,
                        "\"#$(hex(theme.grid_color_focused))\""),
             jsplotdata("unfocused_xgrid_color",
                        "\"#$(hex(theme.grid_color))\""))
-        grid_lines = compose!(context(), static_grid_lines, dynamic_grid_lines)
+        grid_lines = compose!(context(order=theme.grid_line_order), static_grid_lines, dynamic_grid_lines)
     else
-        grid_lines = compose!(context(), static_grid_lines)
+        grid_lines = compose!(context(order=theme.grid_line_order), static_grid_lines)
     end
 
     guide.label || return [PositionedGuide([grid_lines], 0, under_guide_position)]
@@ -808,9 +809,9 @@ function render(guide::YTicks, theme::Gadfly.Theme,
                    "\"#$(    hex(theme.grid_color_focused))\""),
             jsplotdata("unfocused_ygrid_color",
                    "\"#$(hex(theme.grid_color))\""))
-        grid_lines = compose!(context(), static_grid_lines, dynamic_grid_lines)
+        grid_lines = compose!(context(order=theme.grid_line_order), static_grid_lines, dynamic_grid_lines)
     else
-        grid_lines = compose!(context(), static_grid_lines)
+        grid_lines = compose!(context(order=theme.grid_line_order), static_grid_lines)
     end
 
     if !guide.label

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -111,6 +111,9 @@ $(FIELDS)
     "Border color of the main plot panel. (Color or Nothing)",
     panel_stroke,          ColorOrNothing,  nothing
 
+    "Border line width for main plot panel. (Measure)",
+    panel_line_width,      Measure,      0.3mm
+
     "Opacity of the plot background panel. (Float in [0.0, 1.0])",
     panel_opacity,         Float64,         0.0,
     "The keyword argument `panel_opacity` has been deprecated. Instead, provide a e.g. RGBA() color to panel_fill."
@@ -131,6 +134,9 @@ $(FIELDS)
 
     "Width of grid lines. (Measure)",
     grid_line_width,       Measure,         0.2mm
+
+    "Context order of the grid lines (default=0). The plot panel background has a context order of -1. (Int)",
+    grid_line_order,        Int,            0 
 
     "Font used for minor labels such as tick labels and entries in keys. (String)",
     minor_label_font,      AbstractString,          label_font_desc

--- a/test/testscripts/grid_line_style.jl
+++ b/test/testscripts/grid_line_style.jl
@@ -1,7 +1,11 @@
-using Gadfly, RDatasets
+using Gadfly
 
-set_default_plot_size(6inch, 3inch)
+set_default_plot_size(14cm, 10cm)
 
-plot(dataset("datasets", "iris"), x="SepalLength", y="SepalWidth",
-     Theme(grid_line_style=:solid),
-     Geom.point)
+plot(x=[5100, 5400], y=[0, 1], Geom.blank,
+    Guide.yticks(ticks=0:0.1:1),
+    Theme(grid_line_style=:solid, grid_line_width=0.5mm,
+        grid_color="gray92", panel_stroke="black", 
+        grid_line_order=-2,  panel_line_width=1mm)
+)
+


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR:
- closes #1407
- adds `Theme(grid_line_order=0)`
- adds `Theme(panel_line_width=0.3mm)`
- docstrings added to Theme

### Example:

In this example, the grid lines are behind the panel frame.
```julia
plot(x=[5100, 5400], y=[0, 1], Geom.blank,
    Guide.yticks(ticks=0:0.1:1),
    Theme(grid_line_style=:solid, grid_line_width=0.5mm,
        grid_color="gray92", panel_stroke="black", 
        grid_line_order=-2,  panel_line_width=1mm)
)
```
![gridstyle](https://user-images.githubusercontent.com/18226881/77818825-dfc44080-7129-11ea-9243-87ef2afcccc9.png)
