### PR TITLE
Guide.shapekey updates

### DIFF
--- a/docs/src/gallery/shapes.md
+++ b/docs/src/gallery/shapes.md
@@ -1,11 +1,20 @@
 # Shapes
 
-## [`Shape.square`](@ref)
+## [`Shape.square`](@ref) and friends
 
 ```@example
 using Gadfly, RDatasets
-set_default_plot_size(14cm, 8cm)
-plot(dataset("HistData","DrinksWages"),
-     x="Wage", y="Drinks", shape=[Shape.square],
-     Geom.point, Scale.y_log10)
+set_default_plot_size(21cm, 8cm)
+
+p1 = plot(dataset("HistData","DrinksWages"), x="Wage", y="Drinks", 
+    shape=[Shape.square], Scale.y_log10)
+
+aww, mws = dataset("MASS", "Animals"), dataset("quantreg", "Mammals")
+p2 = plot( layer(aww, x=:Body, y=:Brain, shape=["Brain weight"]),
+    layer(mws, x=:Weight, y=:Speed, shape=["Run speed"]),
+    Scale.x_log10, Scale.y_log10, Guide.xlabel("Body weight"),
+    Guide.ylabel("Brain weight and Run speed"),
+    Theme(point_shapes=[Shape.circle, Shape.star1], alphas=[0.0],
+        discrete_highlight_color=identity) )
+hstack(p1, p2)
 ```

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -338,6 +338,6 @@ function discretize_make_ia(values::CategoricalArray{T}, levels::Vector) where {
     return IndirectArray(index, convert(Vector{T},levels))
 end
 function discretize_make_ia(values::CategoricalArray{T}, levels::CategoricalVector{T}) where T
-    _levels = map!(t -> ismissing(t) ? t : get(t), Vector{T}(length(levels)), levels)
+    _levels = map!(t -> ismissing(t) ? t : get(t), Vector{T}(undef, length(levels)), levels)
     discretize_make_ia(values, _levels)
 end

--- a/test/testscripts/Guide_shapekey.jl
+++ b/test/testscripts/Guide_shapekey.jl
@@ -1,8 +1,8 @@
 using Compose, DataFrames, Gadfly
 
-set_default_plot_size(9inch, 3.3inch)
+set_default_plot_size(9inch, 6inch)
 
-theme1 = Theme(point_size=3mm)
+theme1 = Theme(point_size=6pt)
 coord1 = Coord.cartesian(xmin=0.0, xmax=6.0)
 D = DataFrame(x=1:5,
               y=[0.768448, 0.940515, 0.673959, 0.395453, 0.313244],
@@ -20,7 +20,16 @@ pb = plot(D, x=:x, y=:y, shape=:V1, color=:V1,
 pc = plot(D, x=:x, y=:y, shape=:V1, color=:V2,  coord1,
         Guide.colorkey(title="Color"),
         Guide.shapekey(title="Shape ", pos=[0.74w,-0.27h]),
-        Theme(point_size=3mm, key_swatch_color="slategrey"),
+        Theme(point_size=6pt, key_swatch_color="slategrey"),
         Guide.title("Shape!=Color") )
 
-hstack(pa,pb,pc)
+
+pd = plot(D, x=:x, y=:y, shape=[Shape.square], size=[8pt])
+pe = plot()
+pf = plot(Theme(point_size=6pt, alphas=[0.6]),
+            layer(x=0.5:4, y=D.y[1:4], shape=["Gr1"]),
+             layer(x=1:4, y=D.y[1:4], shape=["Gr2"]) )
+        
+
+
+gridstack([pa pb pc; pd pe pf])


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR:
- closes #1366 (see #1385 Roadmap)
- fixes triggering of shapekey (issue 1 in #1366, plot p1 below)
- fixes issue 6 in #1366 (plot p2)
- ~~shapekey integration with 1-length `size` and `color` vectors (plot p3)~~

### Example

```julia
x, y = 1:5, rand(5)
p1 = plot(x=x, y=y, shape=[Shape.square], size=[8pt])

p2 = plot(Theme(point_size=6pt, alphas=[0.6]),
    layer(x=0.5:4, y=rand(4), shape=["Gr1"]),
     layer(x=4*rand(4), y=rand(4), shape=["Gr2"]) )

p3 = plot(x=x, y=y, shape=x, size=[6pt], color=[colorant"orange"])
hstack(p1,p2,p3)
```
![key_shape](https://user-images.githubusercontent.com/18226881/78556286-0e40ca80-7852-11ea-85a2-c28054f4cdb7.png)

