### PR TITLE
bump compat for Cairo to 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ Showoff = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Cairo = "0.7, 0.8"
+Cairo = "0.7, 0.8, 1.0"
 CategoricalArrays = "0.5, 0.6, 0.7"
 Colors = "0.9, 0.10, 0.11, 0.12"
 Compose = "0.7, 0.8"


### PR DESCRIPTION
- [x] I've run the regression tests


### This PR:
- bump compat for Cairo to 1.0 (note Compose v0.8.1 supports Cairo 1.0)
- closes #1409