### PR TITLE
Mapping for layers with functions

### DIFF
--- a/src/poetry.jl
+++ b/src/poetry.jl
@@ -83,8 +83,8 @@ end
 
 Create a layer from a list of functions or expressions in `fs`.
 """
-layer(fs::Vector{T}, lower::Number, upper::Number, elements::ElementOrFunction...) where T <: Base.Callable =
-    layer(y=fs, xmin=[lower], xmax=[upper], Stat.func, Geom.line, elements...)
+layer(fs::Vector{T}, lower::Number, upper::Number, elements::ElementOrFunction...; mapping...) where T <: Base.Callable =
+    layer(y=fs, xmin=[lower], xmax=[upper], Stat.func, Geom.line, elements...; mapping...)
 
 """
     layer(f::Function, lower::Number, upper::Number,
@@ -94,8 +94,8 @@ Create a layer from the function or expression `f`, which takes a single
 argument or operates on a single variable, respectively, between the `lower`
 and `upper` bounds.  See [`Stat.func`](@ref) and [`Geom.line`](@ref).
 """
-layer(f::Function, lower::Number, upper::Number, elements::ElementOrFunction...) =
-        layer(Function[f], lower, upper, elements...)
+layer(f::Function, lower::Number, upper::Number, elements::ElementOrFunction...; mapping...) =
+        layer(Function[f], lower, upper, elements...; mapping...)
 
 """
     layer(f::Function, xmin::Number, xmax::Number, ymin::Number, ymax::Number,

--- a/test/testscripts/function_layers.jl
+++ b/test/testscripts/function_layers.jl
@@ -1,7 +1,12 @@
 using Gadfly, RDatasets
 
-set_default_plot_size(6inch, 3inch)
+set_default_plot_size(5inch, 3inch)
 
-plot(dataset("datasets", "iris"),
-     layer(x=:SepalLength, y=:SepalWidth, Geom.point),
-     layer([sin, cos], 0, 25))
+iris = dataset("datasets", "iris")
+
+fs = [ x->0.3x+1, x->0.3x+1.1 ]
+cs = ["versicolor", "virginica"]
+plot(iris,
+  layer(x=:SepalLength, y=:SepalWidth, color=:Species),
+  layer(fs, 4, 8, color=cs, order=2)
+)


### PR DESCRIPTION
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR:
- fixes an issue identified on discourse:
[Point 2](https://discourse.julialang.org/t/gadfly-layer-order-geom-point-and-geom-line/37798/4?u=mattriks). `layer(Function, ..., order=2)` doesn't work.

### Example:
```julia
using RDatasets
iris = dataset("datasets", "iris")

fs = [ x->0.3x+1, x->0.3x+1.1 ]
cs = ["versicolor", "virginica"]
plot(iris,
  layer(x=:SepalLength, y=:SepalWidth, color=:Species),
  layer(fs, 4, 8, color=cs, order=2),
)
```
![layer_order](https://user-images.githubusercontent.com/18226881/79637004-12a8a400-81bf-11ea-8703-68a86ef73810.png)

