### PR TITLE
Stacked guides

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 This is a log of major changes in Gadfly between releases. It is not exhaustive.
 Each release typically has a number of minor bug fixes beyond what is listed here.
 
+# Version 1.x
+
+* Enable stacked guides (#1423)
+
+
+
 # Version 1.2.0
 
  * Add `Scale.size_radius` and `Scale.size_area` (#1386)

--- a/docs/src/gallery/guides.md
+++ b/docs/src/gallery/guides.md
@@ -59,9 +59,8 @@ Dsleep = dataset("ggplot2", "msleep")
 Dsleep = dropmissing!(Dsleep[:,[:Vore, :Name,:BrainWt,:BodyWt, :SleepTotal]])
 Dsleep.SleepTime = Dsleep.SleepTotal .> 8
 plot(Dsleep, x=:BodyWt, y=:BrainWt, Geom.point, color=:Vore, shape=:SleepTime,
-    Guide.colorkey(pos=[0.05w, -0.25h]),
-    Guide.shapekey(title="Sleep (hrs)", labels=[">8","≤8"], pos=[0.18w,-0.315h]),
-    Scale.x_log10, Scale.y_log10,
+    Scale.x_log10, Scale.y_log10, Guide.colorkey,
+    Guide.shapekey(title="Sleep (hrs)", labels=[">8","≤8"]),
     Theme(point_size=2mm, key_swatch_color="slategrey", 
             point_shapes=[Shape.utriangle, Shape.dtriangle]) )
 ```

--- a/docs/src/gallery/scales.md
+++ b/docs/src/gallery/scales.md
@@ -178,7 +178,7 @@ tipsm = by(tips, [:Day, :Sex], :TotalBill=>mean, :Tip=>mean)
     Scale.shape_discrete(levels=["Thur","Fri","Sat","Sun"]),
     Guide.shapekey(pos=[14.5, 3.8]), Guide.colorkey(pos=[16, 3.87]),
     Theme(discrete_highlight_color=identity, alphas=[0.1],
-        point_size=5pt, key_swatch_color="slate gray")
+        point_size=5pt, key_swatch_color="slategray")
 )
 ```
 

--- a/src/guide/keys.jl
+++ b/src/guide/keys.jl
@@ -46,9 +46,9 @@ function render(guide::ShapeKey, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     title_context, title_width = render_key_title2(guide_title, theme)
     ctxs = render_discrete_key(shape_key_labels, title_context, title_width, theme, shapes=1:nshapes, colors=colors)
     
-    position = right_guide_position
+    position, stackable = right_guide_position, true
     if !isempty(gpos)
-        position = over_guide_position
+        position, stackable = over_guide_position, false
         ctxs = [compose(context(), (context(gpos[1],gpos[2]), ctxs[1]))]
     elseif theme.key_position == :left
         position = left_guide_position
@@ -58,7 +58,7 @@ function render(guide::ShapeKey, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
         position = bottom_guide_position
     end
 
-    return [PositionedGuide(ctxs, 0, position)]
+    return [PositionedGuide(ctxs, 0, position, stackable)]
 end
 
 
@@ -244,9 +244,9 @@ function render(guide::SizeKey, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     title_context, title_width = render_key_title2(guide_title, theme)
     ctxs = render_discrete_key(size_key_labels, title_context, title_width, theme, sizes=sizes, colors=colors)
     
-    position = right_guide_position
+    position, stackable = right_guide_position, true
     if !isempty(gpos)
-        position = over_guide_position
+        position, stackable = over_guide_position, false
         ctxs = [compose(context(), (context(gpos[1], gpos[2]), ctxs[1]))]
     elseif theme.key_position == :left
         position = left_guide_position
@@ -256,7 +256,7 @@ function render(guide::SizeKey, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
         position = bottom_guide_position
     end
 
-    return [PositionedGuide(ctxs, 0, position)]
+    return [PositionedGuide(ctxs, 0, position, stackable)]
 end
 
 

--- a/test/testscripts/Guide_shapekey.jl
+++ b/test/testscripts/Guide_shapekey.jl
@@ -19,7 +19,7 @@ pb = plot(D, x=:x, y=:y, shape=:V1, color=:V1,
 
 pc = plot(D, x=:x, y=:y, shape=:V1, color=:V2,  coord1,
         Guide.colorkey(title="Color"),
-        Guide.shapekey(title="Shape ", pos=[0.74w,-0.27h]),
+        Guide.shapekey(title="Shape "),
         Theme(point_size=6pt, key_swatch_color="slategrey"),
         Guide.title("Shape!=Color") )
 

--- a/test/testscripts/issue723.jl
+++ b/test/testscripts/issue723.jl
@@ -7,7 +7,7 @@ palettef = Scale.lab_gradient(range(HSV(250,1,1), stop=HSV(0,1,1), length=100)..
 colkey = Guide.colorkey(title="Petal\nlength")
 
 plot(iris, x=:SepalLength, y=:SepalWidth, color=:PetalLength,
-    shape=:Species, Guide.shapekey(pos=[4,8]), colkey,
+    shape=:Species, Guide.shapekey(nothing), colkey,
     Scale.color_continuous(colormap=palettef, minvalue=0, maxvalue=7)
 )
 

--- a/test/testscripts/point_color_shape_size.jl
+++ b/test/testscripts/point_color_shape_size.jl
@@ -1,9 +1,17 @@
 using Gadfly
 
-set_default_plot_size(6inch, 6inch)
+set_default_plot_size(5.6inch, 5inch)
 
-plot(x=rand(100), y=rand(100),
-     color=rand([colorant"red",colorant"blue",colorant"green"], 100),
-     shape=rand([Shape.circle,Shape.square,Shape.utriangle], 100),
-     size=rand([1mm, 2mm, 3mm], 100),
-     Geom.point)
+parse_colorant = Gadfly.parse_colorant
+cs = ["red", "green", "blue"]
+shps = ["circle", "square", "triangle"]
+szs = ["1mm", "2mm", "3mm"]
+
+plot(x=rand(100), y=rand(100), color=rand(cs, 100),
+    shape=rand(shps, 100), size=rand(szs, 100),
+    Scale.color_discrete(c->parse_colorant.(cs), levels=cs),
+    Scale.size_discrete2(s->[1mm, 2mm, 3mm], levels=szs),
+    Scale.shape_discrete(levels=shps),
+    Theme(key_swatch_color="gray", key_swatch_size=2mm,
+      point_shapes=[Shape.circle,Shape.square,Shape.utriangle])
+)


### PR DESCRIPTION
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR
- enables stacked guides (Roadmap #1385)
- closes #766

### Examples

```julia
using RDatasets
Dsleep = dataset("ggplot2", "msleep")
Dsleep = dropmissing!(Dsleep[:,[:Vore, :BodyWt, :SleepTotal, :SleepRem]])
Dsleep.SleepTime = Dsleep.SleepTotal .> 8
p1 = plot(Dsleep, x=:BodyWt, y=:SleepRem, Geom.point, color=:Vore, shape=:SleepTime,
    Scale.x_log10, Guide.colorkey(),
    Guide.shapekey(title="Sleep\n(hours) ", labels=[">8","≤8"]),
    Theme(point_size=5pt, key_swatch_color="slategrey",         
        point_shapes=[Shape.utriangle, Shape.dtriangle],
        discrete_highlight_color=identity, alphas=[0.1])
)
```
![stacked_p1](https://user-images.githubusercontent.com/18226881/79795950-14798f80-8398-11ea-8874-2255972a7d8d.png)

The number of key columns is automated. In this example I reduce the size of the testscript plot,
so the keys gain 2 columns. The max number of columns is controlled by `Theme(key_max_columns=4)`.

```julia
p2 = evalfile(dirname(pathof(Gadfly))*"/../test/testscripts/point_color_shape_size.jl")
draw(PNG(5inch, 3.3inch), p2)
```
![stacked_p2](https://user-images.githubusercontent.com/18226881/79796239-8eaa1400-8398-11ea-9ee1-dee029e4a6b4.png)


