### PR TITLE
Enable subplot axis label orientation

### DIFF
--- a/docs/src/gallery/geometries.md
+++ b/docs/src/gallery/geometries.md
@@ -487,7 +487,7 @@ plot(x=rand(25), y=rand(25), Geom.step)
 ```
 
 
-## [`Geom.subplot_grid`](@ref)
+## [[`Geom.subplot_grid`](@ref)](@id Gallery_Geom.subplot_grid)
 
 ```@example
 using Gadfly, RDatasets

--- a/docs/src/gallery/scales.md
+++ b/docs/src/gallery/scales.md
@@ -259,7 +259,7 @@ p2 = plot(df, x=Col.index, y=Col.value, Scale.x_discrete(levels=names(df)))
 hstack(p1,p2)
 ```
 
-## [`Scale.xgroup`](@ref), [`Scale.ygroup`](@ref)
+## [[`Scale.xgroup`](@ref), [`Scale.ygroup`](@ref)](@id Gallery_Scale.xygroup)
 
 ```@example
 using Gadfly, RDatasets

--- a/docs/src/man/compositing.md
+++ b/docs/src/man/compositing.md
@@ -23,6 +23,22 @@ plot(iris, xgroup="Species", x="SepalLength", y="SepalWidth",
 [`Geom.subplot_grid`](@ref) can similarly arrange plots vertically, or
 even in a 2D grid if there are two shared axes.
 
+Subplots have some inner and outer elements, including Guides and Scales. 
+For example, place the guide inside `Geom.subplot_grid(...)` to change the subplot labels, or outside to change the outer plot labels.
+
+```@example facet
+haireye = dataset("datasets", "HairEyeColor")
+palette = ["brown", "blue", "tan", "green"]
+
+plot(haireye, y=:Sex, x=:Freq, color=:Eye, ygroup=:Hair,
+    Geom.subplot_grid(Geom.bar(position=:stack, orientation=:horizontal),
+        Guide.ylabel(orientation=:vertical) ),
+    Scale.color_discrete_manual(palette...),
+    Guide.colorkey(title="Eye\ncolor"),
+    Guide.ylabel("Hair color"), Guide.xlabel("Frequency") )
+```
+
+More examples can be found in the plot gallery at [Geom.subplot_grid](@ref Gallery_Geom.subplot_grid) and [Scale.{x,y}group](@ref Gallery_Scale.xygroup).
 
 ## Stacks
 

--- a/src/geom/subplot.jl
+++ b/src/geom/subplot.jl
@@ -316,7 +316,8 @@ function render(geom::SubplotGrid, theme::Gadfly.Theme,
             push!(guides, get(geom.guides, Guide.XTicks, Guide.xticks()))
 
             if superplot_aes.xgroup !== nothing
-                push!(guides, get(geom.guides, Guide.XLabel, Guide.xlabel(xlabels[j])))
+                gxl = get(geom.guides, Guide.XLabel, Guide.xlabel())
+                push!(guides, gxl.label=="x" ? Guide.xlabel(xlabels[j], gxl.orientation) : gxl)
             end
         else
             push!(guides, Guide.xticks(label=false))
@@ -328,7 +329,8 @@ function render(geom::SubplotGrid, theme::Gadfly.Theme,
             push!(guides, get(geom.guides, Guide.YTicks, Guide.yticks()))
             if superplot_aes.ygroup !== nothing
                 joff += 1
-                push!(guides, get(geom.guides, Guide.YLabel, Guide.ylabel(ylabels[i])))
+                gyl = get(geom.guides, Guide.YLabel, Guide.ylabel())
+                push!(guides, gyl.label=="y" ? Guide.ylabel(ylabels[i], gyl.orientation) : gyl)
             end
         else
             push!(guides, Guide.yticks(label=false))

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -910,7 +910,7 @@ struct XLabel <: Gadfly.GuideElement
     label::Union{(Nothing), AbstractString}
     orientation::Symbol
 end
-XLabel(label; orientation=:auto) = XLabel(label, orientation)
+XLabel(label="x"; orientation=:auto) = XLabel(label, orientation)
 
 """
     Guide.xlabel(label, orientation=:auto)
@@ -977,7 +977,7 @@ struct YLabel <: Gadfly.GuideElement
     label::Union{(Nothing), AbstractString}
     orientation::Symbol
 end
-YLabel(label; orientation=:auto) = YLabel(label, orientation)
+YLabel(label="y"; orientation=:auto) = YLabel(label, orientation)
 
 """
     Guide.ylabel(label, orientation=:auto)

--- a/test/testscripts/subplot_grid_guides.jl
+++ b/test/testscripts/subplot_grid_guides.jl
@@ -1,0 +1,16 @@
+
+using Gadfly, RDatasets
+
+set_default_plot_size(14cm, 8cm)
+
+haireye = dataset("datasets","HairEyeColor")
+palette = ["brown","blue","tan","green"]
+
+plot(haireye, y=:Sex, x=:Freq, color=:Eye, ygroup=:Hair,
+  Geom.subplot_grid(Geom.bar(position=:stack, orientation=:horizontal),
+        Guide.ylabel(orientation=:vertical) ),
+    Scale.color_discrete_manual(palette...),
+    Guide.colorkey(title="Eye\ncolor"),
+    Guide.ylabel("Hair color"), Guide.xlabel("Frequency")
+)
+


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR:
- enables changing the axis label orientation in subplots 
- fixes #424
- adds documentation about subplot inner and outer guides.

### Example
```julia
using RDatasets
haireye = dataset("datasets","HairEyeColor")
palette = ["brown","blue","tan","green"]

plot(haireye, y=:Sex, x=:Freq, color=:Eye, ygroup=:Hair,
    Geom.subplot_grid(Geom.bar(position=:stack, orientation=:horizontal),
        Guide.ylabel(orientation=:vertical) ),
    Scale.color_discrete_manual(palette...),
    Guide.colorkey(title="Eye\ncolor"),
    Guide.ylabel("Hair color"), Guide.xlabel("Frequency")
)
```
![haireye](https://user-images.githubusercontent.com/18226881/80201962-46c11080-8668-11ea-8df6-7c882943acd5.png)
