### PR TITLE
Geom.bar update 1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ Each release typically has a number of minor bug fixes beyond what is listed her
 
 # Version 1.x
 
+* Add Geom.bar(position=:identity) + alpha enabled (#1428)
 * Enable stacked guides (#1423)
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ Each release typically has a number of minor bug fixes beyond what is listed her
 
 # Version 1.x
 
-* Add Geom.bar(position=:identity) + alpha enabled (#1428)
+* Add `Geom.bar(position=:identity)` + alpha enabled (#1428)
 * Enable stacked guides (#1423)
 
 

--- a/docs/src/gallery/geometries.md
+++ b/docs/src/gallery/geometries.md
@@ -41,9 +41,19 @@ plot(De, x=:Date, y=:Unemploy, Geom.line,
 ## [`Geom.bar`](@ref)
 
 ```@example
-using Gadfly, RDatasets
-set_default_plot_size(14cm, 8cm)
-plot(dataset("HistData", "ChestSizes"), x="Chest", y="Count", Geom.bar)
+using ColorSchemes, DataFrames, Distributions, Gadfly
+set_default_plot_size(21cm, 8cm)
+x = range(-4, 4, length=30)
+fn1(μ,x=x) = pdf.(Normal(μ, 1), x)
+D = [DataFrame(x=x, y=fn1(μ), μ="$(μ)") for μ in [-1, 1]]
+cpalette(p) = get(ColorSchemes.viridis, p)
+p1 = plot(D[1], y=:y, x=:x, color=0:29, Geom.bar,
+    Scale.color_continuous(colormap=cpalette),
+    Theme(bar_spacing=-0.2mm, key_position=:none))
+p2 = plot(D[1], x=:x, y=:y, Geom.bar, alpha=range(0.2,0.9, length=30))
+p3 = plot(vcat(D...), x=:x, y=:y, color=:μ, alpha=[0.5],
+    Geom.bar(position=:identity))
+hstack(p1, p2, p3)
 ```
 
 ```@example
@@ -273,13 +283,18 @@ set_default_plot_size(21cm, 16cm)
 D = dataset("ggplot2","diamonds")
 gamma = Gamma(2, 2)
 Dgamma = DataFrame(x=rand(gamma, 10^4))
-p1 = plot(D, x="Price", Geom.histogram)
-p2 = plot(D, x="Price", color="Cut", Geom.histogram)
-p3 = plot(D, x="Price", color="Cut", Geom.histogram(bincount=30))
-p4 = plot(Dgamma, Coord.cartesian(xmin=0, xmax=20),
-    layer(x->pdf(gamma, x), 0, 20, Geom.line, Theme(default_color="black")),
-    layer(x=:x, Geom.histogram(bincount=20, density=true, limits=(min=0,))),
-    Theme(default_color="bisque") )
+p1 = plot(D, x="Price", color="Cut", Geom.histogram)
+p2 = plot(D, x="Price", color="Cut", Geom.histogram(bincount=30))
+p3 = plot(Dgamma, Coord.cartesian(xmin=0, xmax=20),
+    layer(x->pdf(gamma, x), 0, 20, color=[colorant"black"]),
+    layer(x=:x, Geom.histogram(bincount=20, density=true, limits=(min=0,)),
+    color=[colorant"bisque"]))
+a = repeat([0.75, 0.85], outer=40) # opacity
+D2 = [DataFrame(x=rand(Normal(μ,1), 500), μ="$(μ)") for μ in [-1, 1]]
+p4 = plot(vcat(D2...), x=:x,  color=:μ, alpha=[a;a],
+    Geom.histogram(position=:identity, bincount=40, limits=(min=-4, max=4)),
+    Scale.color_discrete_manual("skyblue","moccasin")
+)
 gridstack([p1 p2; p3 p4])
 ```
 

--- a/test/testscripts/color_bar.jl
+++ b/test/testscripts/color_bar.jl
@@ -1,14 +1,14 @@
 using Gadfly
 
-set_default_plot_size(8inch, 3inch)
+set_default_plot_size(6inch, 8inch)
 
-dodge1 = plot(x=["a","a"], y=[3,2], color=["red","blue"],
-      Geom.bar(position=:dodge));
-dodge2 = plot(x=["a","a","b","b"], y=[3,2,1,2], color=["red","blue","red","blue"],
-      Geom.bar(position=:dodge));
-stack1 = plot(x=["a","a"], y=[3,2], color=["red","blue"],
-      Geom.bar(position=:stack));
-stack2 = plot(x=["a","a","b","b"], y=[3,2,1,2], color=["red","blue","red","blue"],
-      Geom.bar(position=:stack));
+c = ["red", "blue"]
+dodge1 = plot(x=["a","a"], y=[3,2], color=c, Geom.bar(position=:dodge))
+dodge2 = plot(x=["a","a","b","b"], y=[3,2,1,2], color=[c;c], Geom.bar(position=:dodge))
+stack1 = plot(x=["a","a"], y=[3,2], color=c, Geom.bar(position=:stack))
+stack2 = plot(x=["a","a","b","b"], y=[3,2,1,2], color=[c;c], Geom.bar(position=:stack))
+identity1 = plot(x=["a","a"], y=[3,2], color=c, alpha=[0.5], Geom.bar(position=:identity))
+identity2 = plot(x=["a","a","b","b"], y=[3,2,1,2], color=[c;c], alpha=[0.5],
+    Geom.bar(position=:identity))
 
-gridstack([dodge1 dodge2; stack1 stack2])
+gridstack([dodge1 dodge2; stack1 stack2; identity1 identity2])

--- a/test/testscripts/histogram_limits.jl
+++ b/test/testscripts/histogram_limits.jl
@@ -4,7 +4,7 @@ set_default_plot_size(6inch, 3inch)
 
 beta = Beta(2,2)
 Dbeta = DataFrame(x=rand(beta, 10^4))
-layer1 = layer(x->pdf(beta, x), 0, 1, Geom.line, Theme(default_color="black"))
+layer1 = layer(x->pdf(beta, x), 0, 1, Theme(default_color="black"))
 p1 = plot(Dbeta, layer1,
     layer(x=:x, Geom.histogram(bincount=20, density=true, limits=(min=0,))),
 )


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR
- adds `Geom.bar(position=:identity)`. `identity` means not stacked or dodged
- enables `alpha` aesthetic for `position=:identity`
- fixes #810: overlapping histograms with same bins  (see plot p3 below) 
- and maybe #1422 (`alpha` can be used to shade or noise bar color)

### Example
```julia
using DataFrames, Distributions
x = range(-4, 4, length=30)
fn1(μ,x=x) = pdf(Normal(μ, 1), x)
D = [DataFrame(x=x, y=fn1(μ), μ="$(μ)") for μ in [-1, 1]]
p1 = plot(D[1], x=:x, y=:y, Geom.bar, alpha=range(0.2,0.9, length=30))
p2 = plot(vcat(D...), x=:x, y=:y, color=:μ, alpha=[0.5], Geom.bar(position=:identity))
a = repeat([0.75, 0.85], outer=40) # opacity
D2 = [DataFrame(x=rand(Normal(μ,1), 500), μ="$(μ)") for μ in [-1, 1]]
p3 = plot(vcat(D2...), x=:x,  color=:μ, alpha=[a;a],
 Geom.histogram(position=:identity, bincount=40, limits=(min=-4, max=4)),
    Scale.color_discrete_manual("skyblue","moccasin"))
hstack(p1, p2, p3)
```
![bar](https://user-images.githubusercontent.com/18226881/80369928-6a878f00-88d2-11ea-8fe5-2a3ae85deeb1.png)



