### PR TITLE
color2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ Each release typically has a number of minor bug fixes beyond what is listed her
 
 # Version 1.x
 
+ * Add aesthetic `color2`, a second color scale (#1436)
  * Enable `color` aesthetic for `Stat.qq` (#1434)
  * Add `Geom.bar(position=:identity)` + alpha enabled (#1428)
  * Enable stacked guides (#1423)

--- a/docs/src/gallery/guides.md
+++ b/docs/src/gallery/guides.md
@@ -36,6 +36,24 @@ hstack(pa, pb)
 ```
 
 
+## [`Guide.color2key`](@ref)
+```@example
+using Gadfly, RDatasets
+set_default_plot_size(14cm, 9cm)
+
+iris = dataset("datasets","iris")
+gp = Geom.polygon(preserve_order=true, fill=true)
+plot(iris,
+    layer(x=:SepalLength, y=:SepalWidth, color2=:Species, alpha=[1.0]),
+    layer(x=:SepalLength, y=:SepalWidth, gp,  order=1,
+        Stat.density2d(levels=[0.05:0.05:0.4;]),
+        Theme(alphas=[0.15], lowlight_color=identity)),
+    Scale.color_continuous,
+    Guide.colorkey,  Guide.color2key(title="Iris"),
+    Theme(point_size=3pt, key_swatch_shape=Shape.circle, alphas=[0.7]))
+```
+
+
 ## [`Guide.manual_color_key`](@ref)
 
 ```@example

--- a/docs/src/gallery/scales.md
+++ b/docs/src/gallery/scales.md
@@ -132,12 +132,21 @@ hstack(pa,pb)
 ## [`Scale.color_none`](@ref)
 
 ```@example
-using Gadfly
-set_default_plot_size(21cm, 8cm)
-xs = ys = 1:10.
-zs = Float64[x^2*log(y) for x in xs, y in ys]
-p1 = plot(x=xs, y=ys, z=zs, Geom.contour);
-p2 = plot(x=xs, y=ys, z=zs, Geom.contour, Scale.color_none);
+using Gadfly, RDatasets
+set_default_plot_size(21cm, 9cm)
+
+iris = dataset("datasets", "iris")
+p1 = plot(iris, x=:SepalLength, y=:SepalWidth, color2=:Species,
+    layer(Geom.density2d(levels=[0.1:0.1:0.4;]),  order=1),
+    Geom.point, Scale.color_continuous,
+    Guide.colorkey, Guide.color2key(title="Iris"),
+    Theme(point_size=3pt, key_swatch_shape=Shape.circle, line_width=1.5pt)
+)
+p2 = plot(iris, x=:SepalLength, y=:SepalWidth, color2=:Species,
+    layer(Geom.density2d(levels=[0.1:0.1:0.4;]),  order=1),
+    Geom.point, Scale.color_none,  Guide.color2key(title="Iris"),
+    Theme(default_color="gray", point_size=3pt, key_swatch_shape=Shape.circle)
+)
 hstack(p1,p2)
 ```
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -213,6 +213,7 @@ hstack(p3, p4)
 | `x` | `x_discrete` | `xticks` |  |
 | `y` | `y_discrete` | `yticks` |  |
 | `color` | `color_discrete` | `colorkey` | (tbd) |
+| `color2` | `color2_discrete` | `color2key` | `color2s` |
 | `shape` | `shape_discrete` | `shapekey` | `point_shapes` |
 | `size` | `size_discrete` | --- | `point_size_min`, `point_size_max` |
 |         | `size_discrete2`| `sizekey` |  `discrete_sizemap` |

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -663,7 +663,7 @@ function render_prepare(plot::Plot)
                                     datas..., subplot_datas...)
 
     # set defaults for key titles
-    keyvars = [:color, :shape, :size]
+    keyvars = [:color, :shape, :size, :color2]
     for (i, layer) in enumerate(plot.layers)
         for kv in keyvars
             fflag = (getfield(layer_aess[i], Symbol(kv,"_key_title")) == nothing) && haskey(layer.mapping, kv) && !isa(layer.mapping[kv], AbstractArray)
@@ -704,7 +704,7 @@ function render_prepare(plot::Plot)
     Stat.apply_statistics(statistics, scales, coord, plot_aes)
 
     # Add some default guides determined by defined aesthetics
-    keytypes = [Guide.ColorKey, Guide.ShapeKey, Guide.SizeKey]
+    keytypes = [Guide.ColorKey, Guide.ShapeKey, Guide.SizeKey, Guide.Color2Key]
     supress_keys = false
     for layer in plot.layers
         if isa(layer.geom, Geom.SubplotGeometry) && any(haskey.((layer.geom.guides,), keytypes))
@@ -1136,6 +1136,7 @@ const default_aes_scales = Dict{Symbol, Dict}(
         :shape  => Scale.shape_identity(),
         :size   => Scale.size_identity(),
         :color  => Scale.color_identity(),
+        :color2 => Scale.color2_identity()
     ),
 
     :numerical => Dict{Symbol, Any}(
@@ -1184,7 +1185,8 @@ const default_aes_scales = Dict{Symbol, Dict}(
         :group      => Scale.group_discrete(),
         :label      => Scale.label(),
         :alpha       => Scale.alpha_discrete(),
-        :linestyle  => Scale.linestyle_discrete()
+        :linestyle  => Scale.linestyle_discrete(),
+        :color2     => Scale.color2_discrete()
     )
 )
 

--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -21,6 +21,7 @@ const NumericalOrCategoricalAesthetic =
     color,        Union{CategoricalAesthetic,Vector,Nothing}
     alpha,        NumericalOrCategoricalAesthetic
     linestyle,    Union{CategoricalAesthetic,Vector,Nothing}
+    color2,       Union{IndirectArray, Vector, Nothing}
 
     label,        CategoricalAesthetic
     group,        CategoricalAesthetic
@@ -66,6 +67,7 @@ const NumericalOrCategoricalAesthetic =
     shape_key_title,      Maybe(AbstractString)
     size_key_title,       Maybe(AbstractString)
     size_key_vals,        Maybe(AbstractDict)
+    color2_key_title,     Maybe(AbstractString)
 
     # mark some ticks as initially invisible
     xtickvisible,         Maybe(Vector{Bool})
@@ -91,6 +93,7 @@ const NumericalOrCategoricalAesthetic =
     ygroup_label, Function, showoff
     shape_label, Function, showoff
     size_label,   Function, showoff
+    color2_label, Function, showoff
 
     # pseudo-aesthetics
     pad_categorical_x, Union{Missing,Bool}, missing

--- a/src/data.jl
+++ b/src/data.jl
@@ -36,6 +36,7 @@
     xsize
     ysize
     color
+    color2
     group
     label
     alpha

--- a/src/geom/point.jl
+++ b/src/geom/point.jl
@@ -30,7 +30,7 @@ Draw scatter plots of the `x` and `y` aesthetics.
 """
 const point = PointGeometry
 
-element_aesthetics(::PointGeometry) = [:x, :y, :size, :color, :shape, :alpha]
+element_aesthetics(::PointGeometry) = [:x, :y, :size, :color, :shape, :alpha, :color2]
 
 # Generate a form for a point geometry.
 #
@@ -64,10 +64,15 @@ function render(geom::PointGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
     end
 
     aes_alpha = eltype(aes.alpha) <: Int ? theme.alphas[aes.alpha] : aes.alpha
+    aes_color = if aes.color2 !== nothing
+        eltype(aes.color2) <: Int ? theme.color2s[aes.color2] : aes.color2
+    else 
+        aes.color
+    end
 
     ctx = context()
 
-    for (x, y, color, size, shape, alpha) in Compose.cyclezip(aes.x, aes.y, aes.color, aes_size, aes.shape, aes_alpha)
+    for (x, y, color, size, shape, alpha) in Compose.cyclezip(aes.x, aes.y, aes_color, aes_size, aes.shape, aes_alpha)
         shapefun = typeof(shape) <: Function ? shape : theme.point_shapes[shape]
         strokecolor = aes.color_key_continuous != nothing && aes.color_key_continuous ?
                     theme.continuous_highlight_color(color) :

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -364,6 +364,15 @@ alpha_discrete(; labels=nothing, levels=nothing, order=nothing) =
 @doc type_discrete_docstr("linestyle") linestyle_discrete(; labels=nothing, levels=nothing, order=nothing) =
         DiscreteScale([:linestyle], labels=labels, levels=levels, order=order)
 
+"""
+    color2_discrete[(; labels=nothing, levels=nothing, order=nothing)]
+    
+Similar to [`Scale.x_discrete`](@ref), except applied to the `color2` aesthetic. The color2 palette
+is set by `Theme(color2s=[])`.
+"""     
+color2_discrete(; labels=nothing, levels=nothing, order=nothing) =
+        DiscreteScale([:color2], labels=labels, levels=levels, order=order)
+
 
 function apply_scale(scale::DiscreteScale, aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
 
@@ -751,8 +760,9 @@ element_aesthetics(scale::IdentityScale) = [scale.var]
 function apply_scale(scale::IdentityScale,
                      aess::Vector{Gadfly.Aesthetics}, datas::Gadfly.Data...)
     for (aes, data) in zip(aess, datas)
-        getfield(data, scale.var) === nothing && continue
-        setfield!(aes, scale.var, getfield(data, scale.var))
+        datavar = getfield(data, scale.var)
+        datavar===nothing && continue
+        setfield!(aes, scale.var, datavar)
     end
 end
 
@@ -787,6 +797,10 @@ shape_identity() = IdentityScale(:shape)
 """
 size_identity() = IdentityScale(:size)
 
+"""
+    color2_identity()
+"""
+color2_identity() = IdentityScale(:color2)
 
 include("scale/scales.jl")
 

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -105,6 +105,9 @@ $(FIELDS)
     "Alpha palette. The default palette is [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]. Customize using a Vector of length one or greater, with 0.0≤values≤1.0",
     alphas,         Vector{Float64}, [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
 
+    "Discrete colors for `color2`.  The default palette is `Scale.default_discrete_colors(50)`. Customize using a `Vector{<:Color}`.", 
+    color2s,               (Vector{<:Color}),    Scale.default_discrete_colors(50)
+
     "Background color used in the main plot panel. (Color or Nothing)",
     panel_fill,            ColorOrNothing,  nothing
 


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [ ] I've added and/or updated the unit tests
- [ ] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors


### This PR:

- Adds `color2`.  `color2` is a second color scale (discrete only, which covers the use cases in #527, #1098, #1171)
- plus `Scale.color2_discrete` and `Guide.color2key`
- `color2` has been enabled for `Geom.point`.  `color2` may be enabled for other Geoms.
- fixes #527, fixes #1098, fixes #1171

### Example

```julia
# plot p1 is the same type of plot that reopened #527

iris = dataset("datasets", "iris")
gp = Geom.polygon(preserve_order=true, fill=true)
p1 = plot(iris, x=:SepalLength, y=:SepalWidth, color2=:Species,
    layer(Geom.density2d(levels=[0.1:0.1:0.4;]),  order=1),
    Geom.point, Scale.color_none,  Guide.color2key(title="", pos=[6.9,5.7]), 
    Theme(default_color="gray", point_size=3pt, key_swatch_shape=Shape.circle, 
        key_position=:inside))
p2 = plot(iris, 
    layer(x=:SepalLength, y=:SepalWidth, color2=:Species, alpha=[1.0]),
    layer(x=:SepalLength, y=:SepalWidth, Stat.density2d(levels=7), gp,  order=1,
        Theme(alphas=[0.2],lowlight_color=identity)), Scale.color_continuous,
    Guide.colorkey, Guide.color2key(title="\n\nIris"), 
    Theme(point_size=3pt, key_swatch_shape=Shape.circle, alphas=[0.7],
    lowlight_color=identity), Guide.ylabel(nothing)
)
hstack(p1, p2)
```
![color2](https://user-images.githubusercontent.com/18226881/81402322-84e42700-9174-11ea-8898-0cd233c1323d.png)
