### PR TITLE
Increase support for `color` aesthetic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ Each release typically has a number of minor bug fixes beyond what is listed her
 
 # Version 1.x
 
+ * Increase support for syntax `color=[colorant"color"]` (#1438)
  * Enable `color` aesthetic for `Stat.qq` (#1434)
  * Add `Geom.bar(position=:identity)` + alpha enabled (#1428)
  * Enable stacked guides (#1423)

--- a/docs/src/gallery/geometries.md
+++ b/docs/src/gallery/geometries.md
@@ -155,23 +155,32 @@ using Gadfly, RDatasets, Distributions
 set_default_plot_size(14cm, 8cm)
 dist = MixtureModel(Normal, [(0.5, 0.2), (1, 0.1)])
 xs = rand(dist, 10^5)
-plot(layer(x=xs, Geom.density, Theme(default_color="orange")),
-     layer(x=xs, Geom.density(bandwidth=0.0003), Theme(default_color="green")),
-     layer(x=xs, Geom.density(bandwidth=0.25), Theme(default_color="purple")),
-     Guide.manual_color_key("bandwidth", ["auto", "bw=0.0003", "bw=0.25"],
-                            ["orange", "green", "purple"]))
+plot(layer(x=xs, Geom.density, color=["auto"]),
+    layer(x=xs, Geom.density(bandwidth=0.0003), color=["bw=0.0003"]),
+    layer(x=xs, Geom.density(bandwidth=0.25), color=["bw=0.25"]),
+    Scale.color_discrete_manual("orange", "green", "purple"),
+    Guide.colorkey(title="bandwidth"))
 ```
 
 
 ## [`Geom.density2d`](@ref)
 
 ```@example
-using Gadfly, Distributions
-set_default_plot_size(14cm, 8cm)
-plot(x=rand(Rayleigh(2),1000), y=rand(Rayleigh(2),1000),
-     Geom.density2d(levels = x->maximum(x)*0.5.^collect(1:2:8)), Geom.point,
-     Theme(key_position=:none),
-     Scale.color_continuous(colormap=x->colorant"red"))
+using Gadfly, Distributions, RDatasets
+set_default_plot_size(21cm, 8cm)
+iris = dataset("datasets", "iris")
+X = rand(Rayleigh(2), 1000,2)
+levelf(x) = maximum(x)*0.5.^collect(1:2:8)
+p1 = plot(x=X[:,1], y=X[:,2], Geom.density2d(levels=levelf), 
+    Geom.point, Scale.color_continuous(colormap=c->colorant"red"),
+    Theme(key_position=:none))
+cs = repeat(Scale.default_discrete_colors(3), inner=50)
+p2 = plot(iris, x=:SepalLength, y=:SepalWidth,
+    layer(x=:SepalLength, y=:SepalWidth, color=cs),
+    layer(Geom.density2d(levels=[0.1:0.1:0.4;]),  order=1),
+    Scale.color_continuous, Guide.colorkey(title=""),
+    Theme(point_size=3pt, line_width=1.5pt))
+hstack(p1, p2)
 ```
 
 

--- a/docs/src/gallery/guides.md
+++ b/docs/src/gallery/guides.md
@@ -43,10 +43,10 @@ using Gadfly, DataFrames
 set_default_plot_size(14cm, 8cm)
 points = DataFrame(index=rand(0:10,30), val=rand(1:10,30))
 line = DataFrame(val=rand(1:10,11), index = collect(0:10))
-pointLayer = layer(points, x="index", y="val", Geom.point,Theme(default_color="green"))
-lineLayer = layer(line, x="index", y="val", Geom.line)
+pointLayer = layer(points, x=:index, y=:val, color=[colorant"green"])
+lineLayer = layer(line, x=:index, y=:val, Geom.line)
 plot(pointLayer, lineLayer,
-     Guide.manual_color_key("Legend", ["Points", "Line"], ["green", "deepskyblue"]))
+    Guide.manual_color_key("Legend", ["Points", "Line"], ["green", "deepskyblue"]))
 ```
 
 

--- a/docs/src/man/compositing.md
+++ b/docs/src/man/compositing.md
@@ -119,7 +119,7 @@ Note that here we used both the DataFrame and AbstractArrays interface to
 [`layer`](@ref), as well a [`Theme`](@ref) object.  See [Themes](@ref) for more
 information on the latter.
 
-You can also share the same DataFrame across different layers:
+You can share the same DataFrame across different layers:
 
 ```julia
 plot(iris,
@@ -150,6 +150,15 @@ There are two rules about layers and Statistics:
         plot(x=xdata, y=rand(30), Geom.point, Stat.binmean(n=5),
          Geom.line, Stat.step)
 
+_Layers and Aesthetics_: Aesthetics can also be shared across layers:
+```@example layer
+plot(iris, Guide.colorkey(title=""),
+    layer(x->0.4x-0.3, 0, 8, color=["Petal"]),
+    layer(x=:SepalLength, y=:SepalWidth, color=["Sepal"]),
+    layer(x=:PetalLength, y=:PetalWidth, color=["Petal"]),
+    layer(x=[2.0], y=[4], shape=[Shape.star1], color=[colorant"red"], size=[8pt]),
+    Theme(alphas=[0.7]))
+```
 
 _Layer order_: the sequence in which layers are drawn, whether they overlap or not, can be
 controlled with the `order` keyword.  Layers with lower order numbers are

--- a/test/testscripts/scaled_and_identity_aesthetics.jl
+++ b/test/testscripts/scaled_and_identity_aesthetics.jl
@@ -1,0 +1,22 @@
+using Gadfly
+
+set_default_plot_size(6inch,3inch)
+
+x, y = [1, 2, 3, 4], [3, 7, 5, 1]
+xmin1, xmax1 = x.-0.1, x.+0.1
+xmin2, xmax2 = x.-0.5, x.-0.3
+
+lyr1 = layer(xmin=xmin1, xmax=xmax1, y=y, Geom.bar, color=[1])
+lyr2 = layer(xmin=xmin2, xmax=xmax2, y=y, Geom.bar, color=[2])
+cs = repeat([colorant"violet", colorant"hotpink"], outer=2)
+
+p1 = plot(Theme(point_size=3pt), lyr1, lyr2,
+    layer(x=x, y=y.+0.9, Geom.point, color=cs),
+    Scale.color_discrete
+)
+p2 = plot(Theme(point_size=3pt), lyr1, lyr2,
+    layer(x=x, y=y.+0.9, Geom.point, color=cs),
+    Scale.color_continuous
+)
+
+hstack(p1, p2)


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR:

- adds extra support for the syntax `color=[colorant"color"]`
- fixes #1437
- Gallery plots updated. Now there are only a few plots which require the syntax 
`layer(..., Theme(default_color= )` e.g. `Geom.line` doesn't directly support single length `color`.

### Example

```julia
D = [DataFrame(x=rand(20), y=rand(20), v=g) for g in ["Group1", "Group2"]]

plot(Coord.cartesian(fixed=true),
      layer((x,y)->x+y, 0, 1.0, 0, 1.0),
      layer(D[1], x=:x, y=:y, color=[colorant"blue"]),
      layer(D[2], x=:x, y=:y, color=[colorant"green"]))
```
![colorants_with_Scales](https://user-images.githubusercontent.com/18226881/82048334-d9008580-96f7-11ea-90c9-eea4b0304d28.png)

