### PR TITLE
Update @add_arg_table, hex and winsor

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -10,7 +10,6 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 Showoff = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 CSV = "0.4, 0.5"

--- a/docs/src/gallery/scales.md
+++ b/docs/src/gallery/scales.md
@@ -145,20 +145,20 @@ hstack(p1,p2)
 
 ```@example
 using DataFrames, Gadfly, RDatasets
-using StatsBase: winsor
 set_default_plot_size(18cm, 8cm)
 
-labs = [ "exp", "sqrt", "log", "winsor", "linear"]
-funcs = [ x->60*(1.0.-exp.(-0.2*x)), x->sqrt.(x)*10, x->log.(x)*10, x->winsor(x, prop=0.15), x->x*0.6 ]
+labs = ["exp", "sqrt", "log", "winsor", "linear"]
+funcs = [x->60*(1.0.-exp.(-0.2*x)), x->sqrt.(x)*10, x->log.(x)*10, 
+    x->clamp.(x,5,26), x->x*0.6]
 x = [1.0:30;]
 D = vcat([DataFrame(x=x, y=f(x), linev=l) for (f,l) in zip(funcs, labs)]...)
-D[134:136,:y] = NaN
+D[134:136,:y] .= NaN
 
-p1 = plot(D, x=:x, y=:y, linestyle=:linev, Geom.line )
-p2 = plot(dataset("datasets", "CO2"), x=:Conc, y=:Uptake, 
+p1 = plot(D, x=:x, y=:y, linestyle=:linev, Geom.line)
+p2 = plot(dataset("datasets", "CO2"), x=:Conc, y=:Uptake,
     group=:Plant, linestyle=:Treatment, color=:Type, Geom.line,
     Scale.linestyle_discrete(order=[2,1]),
-    Theme(key_position=:top, key_title_font_size=-8mm) )
+    Theme(key_position=:top, key_title_font_size=-8mm))
 hstack(p1,p2)
 ```
 

--- a/test/compare_examples.jl
+++ b/test/compare_examples.jl
@@ -3,7 +3,7 @@ include(joinpath(@__DIR__,"..","src","open_file.jl"))
 using ArgParse, LibGit2
 
 s = ArgParseSettings()
-@add_arg_table s begin
+@add_arg_table! s begin
     "--diff"
         help = "print to STDOUT the output of `diff`"
         action = :store_true

--- a/test/testscripts/density_dark.jl
+++ b/test/testscripts/density_dark.jl
@@ -1,4 +1,4 @@
-using Gadfly, RDatasets, Test, Base64
+using Gadfly, RDatasets, Test, Base64, Colors
 
 set_default_plot_size(6inch, 3inch)
 
@@ -8,14 +8,14 @@ p = Gadfly.with_theme(:dark) do
 end
 
     svg_str_dark = stringmime(MIME("image/svg+xml"), p)
-    @test occursin(Base.hex(Gadfly.dark_theme.default_color), svg_str_dark)
+    @test occursin(Colors.hex(Gadfly.dark_theme.default_color), svg_str_dark)
 #    @test occursin("rgba(34,40,48,1)", svg_str_dark) # dark theme background color
 #    @test occursin("rgba(34,40,48,1)", svg_str_dark) # dark theme panel fill
 
     # Test reset.
     p2 = plot(dataset("ggplot2", "diamonds"), x="Price", color="Cut", Geom.density)
     svg_str_light = stringmime(MIME("image/svg+xml"), p2)
-    @test !occursin(Base.hex(Gadfly.dark_theme.default_color), svg_str_light)
+    @test !occursin(Colors.hex(Gadfly.dark_theme.default_color), svg_str_light)
 #    @test !occursin("rgba(34,40,48,1)", svg_str_light)
 
 


### PR DESCRIPTION
- [x] I've updated the documentation
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors


This PR:
- updates `@add_arg_table`, `hex` and `winsor` due to deprecations or changes
  