### PR TITLE
Add disable keymap settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ Each release typically has a number of minor bug fixes beyond what is listed her
 
 # Version 1.x
 
+ * Add `plotroot_keymap(enable::Bool)` (#1445)
  * Add `Guide.manual_discrete_key`, updates `Guide.manual_color_key` (#1441)
  * Increase support for syntax `color=[colorant"color"]` (#1438)
  * Enable `color` aesthetic for `Stat.qq` (#1434)
@@ -45,7 +46,7 @@ Each release typically has a number of minor bug fixes beyond what is listed her
 
   * Support DataFrames.jl v0.11+ (#1090, #1129, #1131)
   * Change `Theme(grid_strokedash=)` to `Theme(grid_line_style=)` and include in docs (#1106)
-  * Add `Geom.ellipse` (#1103)  
+  * Add `Geom.ellipse` (#1103)
   * Improved SVG interactivity (#1037)
 
 # Version 0.6.5

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -851,9 +851,22 @@ function render_prepared(plot::Plot,
         class = string(class, " yscalable")
     end
 
+    if isdefined(@__MODULE__, :used_keymap) && !used_keymap
+      class = string(class, " unused-keymap") # used_keymap flag is defined to unused_plotroot_keymap() function
+    end
+
     compose(c, svgclass(class), jsinclude(gadflyjs, ("Gadfly", "Gadfly")))
 end
 
+
+"""
+    plotroot_keymap(used::Bool)
+
+Setting to disable or enable the keymap associated with rendered graph.
+"""
+function plotroot_keymap(used::Bool)
+  global used_keymap = used
+end
 
 # A convenience version of Compose.draw that let's you skip the call to render.
 """

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -851,8 +851,8 @@ function render_prepared(plot::Plot,
         class = string(class, " yscalable")
     end
 
-    if isdefined(@__MODULE__, :used_keymap) && !used_keymap
-      class = string(class, " unused-keymap") # used_keymap flag is defined to unused_plotroot_keymap() function
+    if isdefined(@__MODULE__, :enable_keymap) && !enable_keymap
+      class = string(class, " keymap-disable") # enable_keymap flag is defined to plotroot_keymap() function
     end
 
     compose(c, svgclass(class), jsinclude(gadflyjs, ("Gadfly", "Gadfly")))
@@ -860,12 +860,12 @@ end
 
 
 """
-    plotroot_keymap(used::Bool)
+    plotroot_keymap(enable::Bool)
 
 Setting to disable or enable the keymap associated with rendered graph.
 """
-function plotroot_keymap(used::Bool)
-  global used_keymap = used
+function plotroot_keymap(enable::Bool)
+  global enable_keymap = enable
 end
 
 # A convenience version of Compose.draw that let's you skip the call to render.

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -191,6 +191,8 @@ var helpscreen_hidden = function(root) {
 Gadfly.plot_mouseover = function(event) {
     var root = this.plotroot();
 
+    if (root.hasClass("unused-keymap")) return;
+
     var keyboard_help = function(event) {
         if (event.which == 191) { // ?
             helpscreen_visible(root);

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -191,7 +191,7 @@ var helpscreen_hidden = function(root) {
 Gadfly.plot_mouseover = function(event) {
     var root = this.plotroot();
 
-    if (root.hasClass("unused-keymap")) return;
+    if (root.hasClass("keymap-disable")) return;
 
     var keyboard_help = function(event) {
         if (event.which == 191) { // ?


### PR DESCRIPTION
# Contributor checklist:

- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've `squash`'ed or `fixup`'ed junk commits with git-rebase
- [x] I've built the docs and confirmed these changes don't cause new errors

# Situation
First, enter characters in the cell with the jupyter notebook.
At that time, if you enter the assigned key (-, +, i, o etc ...), the event of javascript will be triggered and unexpected behavior will occur.
There will also be a delay.
![Gadfly](https://user-images.githubusercontent.com/49139020/83135683-24b42580-a121-11ea-959a-2b6e8b3fe839.gif)

This is one example.
But if it is rendered multiple times, it will be further delayed.

# Proposed changes
- Defined a function that disable a keymap.
- Gadfly.plotroot_keymap(false): disable keymap
