### PR TITLE
Layer aesthetic inheritance improvement

### DIFF
--- a/docs/src/gallery/statistics.md
+++ b/docs/src/gallery/statistics.md
@@ -73,7 +73,7 @@ df = DataFrame(x=x, y=y, ymin=y-ye, ymax=y+ye, g=gshift)
 plot(y=[sigmoid, x->sigmoid(x+2)], xmin=[-10], xmax=[10],
     Geom.line, Stat.func(100), color=[0,2], Guide.xlabel("x"),
     layer(df, x=:x, y=:y, ymin=:ymin, ymax=:ymax, color=:g,
-        Geom.point, Geom.errorbar, Stat.x_jitter(range=1)), 
+        Geom.point, Geom.yerrorbar, Stat.x_jitter(range=1)), 
     Scale.color_discrete_manual("deepskyblue","yellow3", levels=[0,2]),
     Guide.colorkey(title="Function", labels=["Sigmoid(x)", "Sigmoid(x+2)"]),
     Theme(errorbar_cap_length=0mm, key_position=:inside)

--- a/docs/src/man/compositing.md
+++ b/docs/src/man/compositing.md
@@ -168,6 +168,19 @@ plot(iris, Guide.colorkey(title=""),
     layer(x=[2.0], y=[4], shape=[Shape.star1], color=[colorant"red"], size=[8pt]),
     Theme(alphas=[0.7]))
 ```
+And layers can inherit aesthetics from the plot:
+```@example layer
+set_default_plot_size(21cm, 8cm)
+p1 = plot(iris, x=:SepalLength, y=:PetalLength,
+    layer(Geom.smooth(method=:loess), color=["Smooth"]),
+    layer(Geom.point, color=["Points"]))
+
+p2 = plot(iris, x=:SepalLength, y=:PetalLength, color=:Species,
+    Geom.smooth(method=:lm), Geom.point, alpha=[0.6],
+    layer(Geom.smooth(method=:loess), color=[colorant"grey"], order=2))
+hstack(p1, p2)
+```
+Note in some layers, it may be better to use specific Geoms e.g. `Geom.yerrorbar` rather than `Geom.errorbar`, since the latter will attempt to inherit aesthetics for both `Geom.xerrorbar` and `Geom.yerrobar`.
 
 _Layer order_: the sequence in which layers are drawn, whether they overlap or not, can be
 controlled with the `order` keyword.  Layers with lower order numbers are

--- a/src/geom/rectbin.jl
+++ b/src/geom/rectbin.jl
@@ -49,8 +49,7 @@ end
 
 default_statistic(geom::RectangularBinGeometry) = geom.default_statistic
 
-element_aesthetics(::RectangularBinGeometry) =
-        [:x, :y, :xmin, :xmax, :ymin, :ymax, :color, :alpha]
+element_aesthetics(::RectangularBinGeometry) = [:xmin, :xmax, :ymin, :ymax, :color, :alpha]
 
 # Render rectangular bin (e.g., heatmap) geometry.
 #

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1135,7 +1135,7 @@ For confidence bands, use `Stat.smooth()` with `Geom.ribbon`.
 """
 const smooth = SmoothStatistic
 
-function Stat.apply_statistic(stat::SmoothStatistic,
+function apply_statistic(stat::SmoothStatistic,
     scales::Dict{Symbol, Gadfly.ScaleElement},
     coord::Gadfly.CoordinateElement,
     aes::Gadfly.Aesthetics)
@@ -1158,7 +1158,11 @@ function Stat.apply_statistic(stat::SmoothStatistic,
     aes_color =  colorflag ? aes.color : fill(nothing, length(aes.x))
 
     uc = unique(aes_color)
-    groups = Dict(c=>(xs[aes_color.==c], ys[aes_color.==c], aes.x[aes_color.==c]) for c in uc)
+    groups = if length(uc)==1
+        Dict(c=>(xs, ys, aes.x) for c in uc)
+    else
+        Dict(c=>(xs[aes_color.==c], ys[aes_color.==c], aes.x[aes_color.==c]) for c in uc)
+    end
 
     # For aes.y returning a Float is ok if `y` is an Int or a Float
     # There does not seem to be strong demand for other types of `y`


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR:

- Geoms in layers can inherit aesthetics from the plot, if layer aesthetics are incomplete

### Example:
```julia
using RDatasets
iris = dataset("datasets", "iris")
plot(iris, x=:SepalLength, y=:PetalLength,
    layer(Geom.smooth(method=:loess), color=["Smooth"]),
    layer(Geom.point, color=["Points"]),
    Scale.color_discrete_manual("black","deepskyblue")
)
```
![iris_points_smooth](https://user-images.githubusercontent.com/18226881/86522632-30bf9f80-bea4-11ea-9915-1fc75beb5ab1.png)
