### PR TITLE
Geom.segment update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ Each release typically has a number of minor bug fixes beyond what is listed her
 
 # Version 1.x
 
+ * Support one-length aesthetics for `Geom.segment` (#1465)
  * Support one-length aesthetics e.g. `color=[colorant"red"]` for `Geom.line` (#1459)
 
 

--- a/docs/src/gallery/geometries.md
+++ b/docs/src/gallery/geometries.md
@@ -480,16 +480,24 @@ hstack(p1,p2)
 ## [`Geom.segment`](@ref)
 ```@example
 using Gadfly, DataFrames, ColorSchemes
-set_default_plot_size(14cm, 14cm)
+set_default_plot_size(21cm, 8cm)
 n = 1000
 x, y = cumsum(randn(n)), cumsum(randn(n))
-D = DataFrame(x1=x[1:end-1], y1=y[1:end-1], x2=x[2:end], y2=y[2:end], colv=1:n-1)
+D1 = DataFrame(x1=x[1:end-1], y1=y[1:end-1], x2=x[2:end], y2=y[2:end], colv=1:n-1)
 palettef(c::Float64) = get(ColorSchemes.viridis, c)
+a = range(0, stop=7π/4, length=8)+ 0.2*randn(8)
+D2 = [DataFrame(x2=x, y2=x, x=x.+sin.(a)/r, y=x.+r*cos.(a),
+        ls=rand(["A","A","B"], 8)) for (x,r) in zip([1,-1], [0.4,0.3])]
 
-plot(D, x=:x1, y=:y1, xend=:x2, yend=:y2,
-     color = :colv, Geom.segment, Coord.cartesian(aspect_ratio=1.0),
+p1 = plot(D1, x=:x1, y=:y1, xend=:x2, yend=:y2,
+     color=:colv, Geom.segment, Coord.cartesian(fixed=true),
      Scale.color_continuous(colormap=palettef, minvalue=0, maxvalue=1000)
 )
+p2 = plot(vcat(D2...), x=:x, y=:y, xend=:x2, yend=:y2,
+     color=:x2, linestyle=:ls, Geom.point, Geom.segment,
+     Scale.linestyle_discrete(levels=["A","B"]),
+     Scale.color_discrete, Theme(key_position=:none, point_size=3.5pt))
+hstack(p1, p2)
 ```
 
 

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -765,8 +765,8 @@ end
 @deprecate xticks(ticks) xticks(ticks=ticks)
 
 ### add hinges and fences to y-axis?
-input_aesthetics(stat::TickStatistic) = stat.axis=="x" ? [:x, :xmin, :xmax, :xintercept] :
-    [:y, :ymin, :ymax, :yintercept, :middle, :lower_hinge, :upper_hinge, :lower_fence, :upper_fence]
+input_aesthetics(stat::TickStatistic) = stat.axis=="x" ? [:x, :xmin, :xmax, :xintercept, :xend] :
+    [:y, :ymin, :ymax, :yintercept, :middle, :lower_hinge, :upper_hinge, :lower_fence, :upper_fence, :yend]
 output_aesthetics(stat::TickStatistic) = stat.axis=="x" ? [:xtick, :xgrid] : [:ytick, :ygrid]
 
 xy_ticks(var,in_aess,out_aess) = """

--- a/test/testscripts/vector.jl
+++ b/test/testscripts/vector.jl
@@ -11,7 +11,7 @@ xsc  = Scale.x_continuous(minvalue=0.0, maxvalue=100)
 ysc  = Scale.y_continuous(minvalue=0.0, maxvalue=100)
 
 p1 = plot(D, x=:x1, y=:x2, xend=:x3, yend=:x4, Geom.segment(arrow=true), xsc, ysc);
-p2 = plot(D, x=:x1, y=:x2, xend=:x3, yend=:x4, Geom.vector, xsc, ysc);
+p2 = plot(D, x=:x1, y=:x2, xend=:x3, yend=:x4, color=[colorant"orange"], linestyle=[:dash], Geom.vector, xsc, ysc);
 
 p3 = plot(z=(x,y)->x*exp(-(x^2+y^2)), 
         xmin=[-2], xmax=[2], ymin=[-2], ymax=[2], 


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR

- updates `Geom.segment` (fixes #1337)
- `Geom.segment` supports one-length aesthetics e.g. `linestyle=[:dash]`, `color=[colorant"red"]`
- adds gallery example of the type of plot in #1337 (see p2 below)

### Examples

```julia
a = range(0, stop=7π/4, length=8)+ 0.2*randn(8)
D2 = [DataFrame(x2=x, y2=x, x=x.+sin.(a)/r, y=x.+r*cos.(a), 
        ls=rand(["A","A","B"], 8)) for (x,r) in zip([1,-1], [0.4,0.3])]

p1 = plot(D2[1], x=[1], y=[1], xend=:x, yend=:y, Geom.segment, color=[colorant"forestgreen"], linestyle=[:dash])
p2 = plot(vcat(D2...),
    x=:x, y=:y, xend=:x2, yend=:y2, color=:x2, linestyle=:ls, Geom.point, Geom.segment, 
    Scale.linestyle_discrete(levels=["A","B"]), Scale.color_discrete,
    Theme(key_position=:none, point_size=3.5pt))
hstack(p1, p2)
```
![geom_segment](https://user-images.githubusercontent.com/18226881/87844771-fc1c0100-c903-11ea-9322-4cd2360f965b.png)

