### PR TITLE
Update instructions for using PackageCompiler.jl

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -62,20 +62,31 @@ Alternatively, one can avoid the first-time-to-plot penalty altogther by
 ahead-of-time (AOT) compiling Gadfly into the Julia system image using
 [PackageCompiler.jl](https://github.com/JuliaLang/PackageCompiler.jl).
 
+For example, after making the directory for PackageCompiler.jl,
+
+```bash
+mkdir $HOME/JuliaGadflySysImage
+cd $HOME/JuliaGadflySysImage
+```
+
+one can complile Gadfly.jl and create the sysimage as follows:
+
 ```julia
-julia> ]dev PackageCompiler
+(@v.1.4) pkg> add PackageCompiler
 julia> using PackageCompiler
-julia> compile_package("Gadfly", force=false)
+(@v.1.4) pkg> activate .
+(JuliaGadflySysImage) pkg> add Gadfly
+julia> create_sysimage(:Gadfly; sysimage_path="GadFlySysimage.so")
+julia> exit()
 ```
 
 At the end of the resulting copius output will be the command to launch this
-custom version of julia:  something like `julia -J
-$HOME/.julia/dev/PackageCompiler/sysimg/sys.dylib`.  Make it convenient by
-putting an alias in your .bashrc: `alias julia-gadfly="julia -J ..."`.
+custom version of julia: something like `julia --sysimage $HOME/JuliaGadflySysImage/GadFlySysimage.so`.
+Make it convenient by putting an alias in your .bashrc: `alias julia-gadfly="julia --sysimage ..."`.
 
 Note that multiple packages can be built into a new system image at the same
-time by adding additional arguments: `compile_package("Gadfly",
-"MyOtherFavoritePackage", ...)`.  Conversely, you don't have to precompile
+time by adding additional arguments: `create_sysimage([:Gadfly, 
+:MyOtherFavoritePackage], ...)`.  Conversely, you don't have to precompile
 everything you need though, as `]add ...` still works.
 
 Now that `using Gadfly` takes just a split second, there's no reason not to

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -94,10 +94,6 @@ do so automatically in your `$HOME/.julia/config/startup.jl` file.
 
 A few caveats:
 
-- PackageCompiler is a work in progress, and the most recent tagged release
-  sometimes (currently as of this writing) does not work.  Hence the `dev`
-  instead of `add` command to install.
-
 - Updating to the latest versions of compiled packages requires a recompile.
   `]up`ing only works for those that haven't been built into the system image.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -62,7 +62,7 @@ Alternatively, one can avoid the first-time-to-plot penalty altogther by
 ahead-of-time (AOT) compiling Gadfly into the Julia system image using
 [PackageCompiler.jl](https://github.com/JuliaLang/PackageCompiler.jl).
 
-For example, after making the directory for PackageCompiler.jl,
+For example, after making a directory for creating sysimage
 
 ```bash
 mkdir $HOME/JuliaGadflySysImage


### PR DESCRIPTION
I found that [PackageCompiler.jl](https://github.com/JuliaLang/PackageCompiler.jl) had been updated and procedures to compile packages had been changed.
This PR gives some modifications to instructions to compile Gadfly.jl in the document.

In my environment, PackageCompiler.jl added by `]add PackageCompiler` (not `]dev PackageCompiler` )  works well, so I think the first caveat may not be necessary.

> PackageCompiler is a work in progress, and the most recent tagged release
> sometimes (currently as of this writing) does not work.  Hence the `dev`
> instead of `add` command to install.
