### PR TITLE
Flag Scale.color_none for deprecation

### DIFF
--- a/docs/src/gallery/geometries.md
+++ b/docs/src/gallery/geometries.md
@@ -117,10 +117,19 @@ hstack(p1, p2)
 ## [`Geom.contour`](@ref)
 
 ```@example
-using Gadfly
-set_default_plot_size(14cm, 8cm)
-plot(z=(x,y) -> x*exp(-(x-round(Int, x))^2-y^2),
-     xmin=[-8], xmax=[8], ymin=[-2], ymax=[2], Geom.contour)
+using DataFrames, Gadfly
+set_default_plot_size(21cm, 8cm)
+x2, cb = -2:0.2:2, [colorant"black"]
+D = DataFrame(x=repeat(x2, outer=length(x2)), y=repeat(x2, inner=length(x2)))
+D.z = D.x.*exp.(-(D.x.^2 + D.y.^2))
+D2 = DataFrame(x=0.8*randn(10), y=0.8*randn(10), r=rand(10))
+
+p1 = plot(z=(x,y) -> x*exp(-(x-round(Int, x))^2-y^2),
+     xmin=[-10], xmax=[10], ymin=[-2], ymax=[2], Geom.contour)
+p2 = plot(D, x=:x, y=:y,  layer(D2, color=:r, Geom.point),
+  layer(z=:z, Geom.contour(levels=[-0.1:-0.1:-0.5;]), linestyle=[:dash], color=cb),
+    layer(z=:z, Geom.contour(levels=[0.1:0.1:0.5;]),  color=cb))
+hstack(p1, p2)
 ```
 
 ```@example

--- a/docs/src/gallery/scales.md
+++ b/docs/src/gallery/scales.md
@@ -130,17 +130,6 @@ hstack(pa,pb)
 ```
 
 
-## [`Scale.color_none`](@ref)
-
-```@example
-using Gadfly
-set_default_plot_size(21cm, 8cm)
-xs = ys = 1:10.
-zs = Float64[x^2*log(y) for x in xs, y in ys]
-p1 = plot(x=xs, y=ys, z=zs, Geom.contour);
-p2 = plot(x=xs, y=ys, z=zs, Geom.contour, Scale.color_none);
-hstack(p1,p2)
-```
 
 ## [`Scale.linestyle_discrete`](@ref)
 

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -696,8 +696,8 @@ function render_prepare(plot::Plot)
         end
     end
 
-    # Scale.color_none maybe deprecated, this conditional can be removed then
-    haskey(scales, :color) && isa(scales[:color], Scale.color_none) && (supress_colorkey = true)
+    # Scale.color_none to be deprecated, this conditional can be removed then
+    haskey(scales, :color) && isa(scales[:color], Scale.NoneColorScale) && (supress_colorkey = true)
 
     if supress_colorkey
         deleteat!(keytypes, 1)

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -428,9 +428,13 @@ end
     color_none
 
 Suppress the default color scale that some statistics impose by setting the
-`color` aesthetic to `nothing`.
+`color` aesthetic to `nothing`. (To be deprecated)
 """
-const color_none = NoneColorScale
+
+function color_none()
+    @warn """`Scale.color_none` to be deprecated. Instead use e.g. `plot(..., Geom.contour, color=[colorant"black"])`""" 
+    return NoneColorScale()
+end
 
 element_aesthetics(scale::NoneColorScale) = [:color]
 

--- a/test/testscripts/contour.jl
+++ b/test/testscripts/contour.jl
@@ -13,7 +13,7 @@ for (i, x) in enumerate(range(-8., stop=8., length=200)), (j, y) in enumerate(ra
     M[i, j] = f(x, y)
 end
 
-p1 = plot(x=xs, y=ys, z=zs, Geom.contour, Scale.color_none)
+p1 = plot(x=xs, y=ys, z=zs, Geom.contour, color=[colorant"black"])
 p2 = plot((x,y) -> x*exp(-(x-(round(Int, x)))^2-y^2), -8., 8, -2., 2)
 p3 = plot(layer((x,y) -> x*exp(-(x-(round(Int, x)))^2-y^2), -8., 8, -2., 2),
      layer((x, y) -> sqrt(hypot(x, y)), -2, 2, -1, 1),


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR

`Scale.color_none` was not the right design, see https://github.com/GiovineItalia/Gadfly.jl/issues/527#issuecomment-69364342. This PR flags `Scale.color_none` for deprecation, in favour of e.g. `plot(..., Geom.contour, color=[colorant"black"])`. 

- fixes #527
