### PR TITLE
force type `Vector{Colorant}` for `ManualDiscreteKey`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Each release typically has a number of minor bug fixes beyond what is listed her
  * Better define what scales are included in the (internal) `scales` dict (#1468)
  * Support one-length aesthetics for `Geom.segment` (#1465)
  * Support one-length aesthetics e.g. `color=[colorant"red"]` for `Geom.line` (#1459)
+ * Fix dispatch problem on `ManualDiscreteKey` as `Vector{Colorant}` (#1470)
 
 
 

--- a/src/guide/keys.jl
+++ b/src/guide/keys.jl
@@ -292,7 +292,7 @@ function ManualDiscreteKey(;title="", labels=String[], pos=[], color=Colorant[],
         swatches = collect(Tuple, zip(cataes[notempty]...))
         !allunique(swatches) && error("Swatches should not be repeated in a manual key")
     end
-    return ManualDiscreteKey(title, labels, pos, clrs, shps, szs,  true)
+    return ManualDiscreteKey(title, labels, pos, Vector{Colorant}(clrs), shps, szs,  true)
 end
 
 


### PR DESCRIPTION
Fixes an unexpected dispatch problem with a minimal code change. Seemed like the best solution after various attempts to fix downstream with user code, but didn't work.  This issue also seems to be a regression since the user code has been working for quite some time.

```julia
ERROR: LoadError: LoadError: TypeError: in new, expected Array{Colorant,1}, got a value of type Array{RGB{Normed{UInt8,8}},1}
Stacktrace:
 [1] Gadfly.Guide.ManualDiscreteKey(::String, ::Array{String,1}, ::Array{Any,1}, ::Array{RGB{Normed{UInt8,8}},1}, ::Array{Function,1}, ::Array{Measures.Measure,1}, ::Bool) at /home/dehann/.julia/dev/Gadfly/src/guide/keys.jl:267
 [2] Gadfly.Guide.ManualDiscreteKey(; title::String, labels::Array{String,1}, pos::Array{Any,1}, color::Array{String,1}, shape::Array{Function,1}, size::Array{Measures.Measure,1}) at /home/dehann/.julia/dev/Gadfly/src/guide/keys.jl:295
 [3] #manual_color_key#131 at /home/dehann/.julia/dev/Gadfly/src/guide/keys.jl:321 [inlined]
 [4] manual_color_key at /home/dehann/.julia/dev/Gadfly/src/guide/keys.jl:321 [inlined]
 [5] plotKDE(::Array{BallTreeDensity,1}; c::Array{String,1}, N::Int64, rmax::Float64, rmin::Float64, axis::Nothing, dims::Nothing, xlbl::String, title::String, legend::Array{String,1}, dimLbls::Nothing, levels::Int64, fill::Bool, points::Bool, layers::Bool, overlay::Nothing) at /home/dehann/.julia/packages/KernelDensityEstimatePlotting/49JcX/src/KernelDensityEstimatePlotting.jl:356
```

Not sure if this is related, but:
```julia
julia> using Colors
julia> RGB isa Colorant
false
julia> RGB <: Colorant
true

```

# Contributor checklist:

<!-- Make sure to complete all of these that apply -->

- [ ] N/A I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [ ] N/A I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've `squash`'ed or `fixup`'ed junk commits with git-rebase
- [x] I've built the docs and confirmed these changes don't cause new errors


# Proposed changes

- force type `Vector{Colorant}`for `ManualDiscreteKey` in guide/keys.jl
