### PR TITLE
fix render bug when aes.color_key_colors=nothing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Each release typically has a number of minor bug fixes beyond what is listed her
  * Better define what scales are included in the (internal) `scales` dict (#1468)
  * Support one-length aesthetics for `Geom.segment` (#1465)
  * Support one-length aesthetics e.g. `color=[colorant"red"]` for `Geom.line` (#1459)
+ * Bug fix `hstack` --> `render` on `isempty(nothing)` error; by adding preceding `.color_key_colors === nothing` check (#1471)
 
 
 

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -396,7 +396,7 @@ end
 function render(guide::ColorKey, theme::Gadfly.Theme,
                 aes::Gadfly.Aesthetics)
 
-    (theme.key_position == :none || isempty(aes.color_key_colors)) && return PositionedGuide[]
+    (theme.key_position == :none || aes.color_key_colors === nothing || isempty(aes.color_key_colors)) && return PositionedGuide[]
     gpos = guide.pos
     (theme.key_position == :inside && gpos === nothing) &&  (gpos = [0.7w, 0.25h])
 


### PR DESCRIPTION
https://github.com/GiovineItalia/Gadfly.jl/blob/d507b208cab7da3dfd9104ada3a3d2281ef5646c/src/guide.jl#L399
check on `isempty(aes.color_key_colors==nothing)` produces a Julia base error:
```julia
julia> isempty(nothing)
ERROR: MethodError: no method matching iterate(::Nothing)
Closest candidates are:
  iterate(::Base.RegexMatchIterator) at regex.jl:552
  iterate(::Base.RegexMatchIterator, ::Any) at regex.jl:552
  iterate(::LibGit2.GitBranchIter) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/LibGit2/src/reference.jl:343
  ...
Stacktrace:
 [1] isempty(::Nothing) at ./essentials.jl:737
```
hence added a trivial test `aes.color_key_colors === nothing || isempty(aes.color_key_colors)`.

I had some trouble reproducing a MWE beyond the bigger block of working code I have, but either way there are several `=== nothing` checks in surrounding code already, and `isempty(nothing)` is a clear failure case.

# Contributor checklist:

<!-- Make sure to complete all of these that apply -->

- [ ] N/A I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [ ] N/A I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've `squash`'ed or `fixup`'ed junk commits with git-rebase
- [x] I've built the docs and confirmed these changes don't cause new errors

-----

EDIT, 

#### Original error stack
```julia
ERROR: LoadError: LoadError: MethodError: no method matching iterate(::Nothing)
Closest candidates are:
  iterate(::PyObject) at /home/dehann/.julia/packages/PyCall/zqDXB/src/pyiterator.jl:81
  iterate(::PyObject, ::Any) at /home/dehann/.julia/packages/PyCall/zqDXB/src/pyiterator.jl:81
  iterate(::Base.RegexMatchIterator) at regex.jl:552
  ...
Stacktrace:
 [1] isempty(::Nothing) at ./essentials.jl:737
 [2] render(::Gadfly.Guide.ColorKey, ::Theme, ::Gadfly.Aesthetics) at /home/dehann/.julia/dev/Gadfly/src/guide.jl:399
 [3] render(::Gadfly.Guide.ColorKey, ::Theme, ::Gadfly.Aesthetics, ::Bool) at /home/dehann/.julia/dev/Gadfly/src/guide.jl:143
 [4] render_prepared(::Plot, ::Gadfly.Coord.Cartesian, ::Gadfly.Aesthetics, ::Array{Gadfly.Aesthetics,1}, ::Array{Array{Gadfly.StatisticElement,1},1}, ::Array{Array{Gadfly.Aesthetics,1},1}, ::Array{Array{Gadfly.Data,1},1}, ::Dict{Symbol,Gadfly.ScaleElement}, ::Array{Gadfly.GuideElement,1}; table_only::Bool, dynamic::Bool) at /home/dehann/.julia/dev/Gadfly/src/Gadfly.jl:817
 [5] render_prepared(::Plot, ::Gadfly.Coord.Cartesian, ::Gadfly.Aesthetics, ::Array{Gadfly.Aesthetics,1}, ::Array{Array{Gadfly.StatisticElement,1},1}, ::Array{Array{Gadfly.Aesthetics,1},1}, ::Array{Array{Gadfly.Data,1},1}, ::Dict{Symbol,Gadfly.ScaleElement}, ::Array{Gadfly.GuideElement,1}) at /home/dehann/.julia/dev/Gadfly/src/Gadfly.jl:798
 [6] render(::Plot) at /home/dehann/.julia/dev/Gadfly/src/Gadfly.jl:744
 [7] #128 at ./none:0 [inlined]
 [8] iterate at ./generator.jl:47 [inlined]
 [9] collect at ./array.jl:686 [inlined]
 [10] hstack(::Plot, ::Plot) at /home/dehann/.julia/dev/Gadfly/src/Gadfly.jl:906
 [11] plotPose(::Pose2, ::Array{BallTreeDensity,1}, ::String; levels::Int64, c::Nothing, axis::Nothing, scale::Float64, overlay::Nothing, hdl::Array{Any,1}) at /home/dehann/.julia/dev/RoMEPlotting/src/RobotViz.jl:569
```