### PR TITLE
Geom_ribbon: replace nan separator by missing

### DIFF
--- a/src/geom/ribbon.jl
+++ b/src/geom/ribbon.jl
@@ -56,7 +56,7 @@ function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
 
     kys = keys(max_points)
     polys = [collect(Tuple{XT, YT}, Iterators.flatten((min_points[k], max_points[k]))) for k in kys]
-    lines = [collect(Tuple{XT, YT}, Iterators.flatten((min_points[k], [(last(min_points[k])[1], oneunit(YT)*NaN)], max_points[k]))) for k in kys]
+    lines = [collect(Tuple{XT, Union{YT, Missing}}, Iterators.flatten((min_points[k], [(last(min_points[k])[1], missing)], max_points[k]))) for k in kys]
 
     n = length(kys)
     colors = Vector{Union{Colorant, String}}(undef, n)


### PR DESCRIPTION

- [x] I've run the regression tests (involving `Geom.ribbon`)
- [x] I've built the docs and confirmed these changes don't cause new errors


### This PR
- fixes #1477 
- The solution here is made possible by  GiovineItalia/Compose.jl#397

