### PR TITLE
Zoom fixes

### DIFF
--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -110,9 +110,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
             };
         }
 
-        this.node.addEventListener(
-            /Firefox/i.test(navigator.userAgent) ? "DOMMouseScroll" : "mousewheel",
-            fn2);
+        this.node.addEventListener("wheel", fn2);
 
         return this;
     };
@@ -817,7 +815,20 @@ Gadfly.guide_background_drag_onend = function(event) {
 
 Gadfly.guide_background_scroll = function(event) {
     if (event.shiftKey) {
-        increase_zoom_by_position(this.plotroot(), 0.001 * event.wheelDelta);
+        // event.deltaY is either the number of pixels, lines, or pages scrolled past.
+        var actual_delta;
+        switch (event.deltaMode) {
+            case 0: // Chromium-based
+                actual_delta = -event.deltaY / 1000.0;
+                break;
+            case 1: // Firefox
+                actual_delta = -event.deltaY / 50.0;
+                break;
+            default:
+                actual_delta = -event.deltaY;
+        }
+        // Assumes 20 pixels/line to get reasonably consistent cross-browser behaviour.
+        increase_zoom_by_position(this.plotroot(), actual_delta);
         event.preventDefault();
     }
 };


### PR DESCRIPTION
<!-- Replace XXX with the issue number that this PR fixes, remove if there is no corresponding issue -->
Fixes #1504 

# Contributor checklist:

<!-- Make sure to complete all of these that apply -->

- [ ] I've updated the documentation to reflect these changes
- [ ] I've added an entry to `NEWS.md`
- [ ] I've added and/or updated the unit tests
- [ ] I've run the regression tests
- [x] I've `squash`'ed or `fixup`'ed junk commits with git-rebase
- [x] I've built the docs and confirmed these changes don't cause new errors


# Proposed changes

- The `mousewheel` and `DOMMouseScroll` events are deprecated (`wheelDelta` was undefined causing the NaN's) so I swapped to the `wheel` event, which has [better](https://caniuse.com/?search=wheel) browser support. 
- Made some changes to address the docs issue in #1272 - I built the docs and zoom is now working on all the browsers I tested (additionally, the co-ordinates are now correct)
    - Plotting from REPL worked since the plot was always at the exact top-left corner of the page

This does not completely fix the original IJulia notebook problem in the linked issue (when shift left-click + dragging to zoom) as jupyter seems to do something weird with mouse events. 
