### PR TITLE
Support Measures units more in x,y scales

### DIFF
--- a/docs/src/gallery/geometries.md
+++ b/docs/src/gallery/geometries.md
@@ -348,20 +348,25 @@ hstack(p1,p2)
 ## [`Geom.label`](@ref)
 
 ```@example
-using Gadfly, RDatasets
-set_default_plot_size(14cm, 8cm)
-plot(dataset("ggplot2", "mpg"), x="Cty", y="Hwy", label="Model",
+using DataFrames, Gadfly, RDatasets
+import Gadfly: w, h   # for relative units
+set_default_plot_size(21cm, 8cm)
+df = DataFrame(x=[0.6w, 0.6w], y=[0.6h, 0.7h], label=["Text 1", "Text 2"])
+p1 = plot(x=1.0:5, y=[0.21, 0.81, 0.68, 0.76, 0.18], Geom.point,
+     layer(df, x=:x, y=:y, label=:label, Geom.label(position=:right)))
+p2 = plot(dataset("ggplot2", "mpg"), x="Cty", y="Hwy", label="Model",
      Geom.point, Geom.label)
+hstack(p1, p2)
 ```
 
 ```@example
 using Gadfly, RDatasets
 set_default_plot_size(21cm, 8cm)
-p1 = plot(dataset("MASS", "mammals"), x="Body", y="Brain", label=1,
+p3 = plot(dataset("MASS", "mammals"), x="Body", y="Brain", label=1,
      Scale.x_log10, Scale.y_log10, Geom.point, Geom.label)
-p2 = plot(dataset("MASS", "mammals"), x="Body", y="Brain", label=1,
+p4 = plot(dataset("MASS", "mammals"), x="Body", y="Brain", label=1,
      Scale.x_log10, Scale.y_log10, Geom.label(position=:centered))
-hstack(p1,p2)
+hstack(p3,p4)
 ```
 
 

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -1114,7 +1114,7 @@ const default_aes_scales = Dict{Symbol, Dict}(
     ),
 
     :functional => Dict{Symbol, Any}(
-        :x      => Scale.x_discrete(),
+        :x      => Scale.x_func(),
         :z      => Scale.z_func(),
         :y      => Scale.y_func(),
         :shape  => Scale.shape_identity(),

--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -308,7 +308,7 @@ cat_aes_var!(a::AbstractVector{T}, b::AbstractVector{U}) where {T<:Measure, U} =
     isabsolute(T) ? [a..., b...] : b
 
 cat_aes_var!(a::AbstractVector{T}, b::AbstractVector{U}) where {T, U<:Measure} =
-    isabsolute(U) ? a : [a..., b...]
+    isabsolute(U) ? [a..., b...] : a
 
 
 

--- a/test/testscripts/measures_units.jl
+++ b/test/testscripts/measures_units.jl
@@ -1,15 +1,21 @@
-using Gadfly
+using DataFrames, Gadfly
+import Compose: w, h
 
-set_default_plot_size(8inch,3.3inch)
+set_default_plot_size(12inch,3.3inch)
 
 # Issue #1357
+
+df = DataFrame(x=[0.6w, 0.6w], y=[0.6h, 0.7h], label=["Text 1", "Text 2"])
+lyr1 = layer(x=1.0:5, y=[0.21, 0.81, 0.68, 0.76, 0.18], Geom.point)
+lyr2 = layer(df, x=:x, y=:y, label=:label, Geom.label(position=:right))
+lyr3 = layer(xintercept=[0.5inch], Geom.vline(color="orange"))
 
 p1 = plot(xmin=[.25], xmax=[.75], Geom.band, color=[colorant"red"])
 p2 = plot(xmin=[.25], xmax=[.75], Geom.band, color=[colorant"red"],
     layer(Geom.rect, xmin=[0], xmax=[1], ymin=[0], ymax=[1], color=[colorant"blue"]))
-p3 = plot(x=[0,10], y=[0,1], Geom.blank,
-    layer(xintercept=[1.2inch], Geom.vline(color="black")) )
+p3 = plot(lyr1, lyr2, lyr3)
+p4 = plot(lyr1, lyr2, lyr3, Scale.x_discrete)
+    
 
-
-hstack(p1, p2, p3)
+hstack(p1, p2, p3, p4)
 


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR

- adds more support for Measures units in `x`,`y` scales
- fixes a mistake in function `cat_aes_var!`

### Example

- Add text at relative positions on a plot

```julia
using DataFrames, Gadfly
import Gadfly: w, h

df = DataFrame(x=[0.6w, 0.6w], y=[0.6h, 0.7h], label=["Text 1", "Text 2"])
layer1 = layer(x=1.0:5, y=[0.21, 0.81, 0.68, 0.76, 0.18], Geom.point)
layer2 = layer(df, x=:x, y=:y, label=:label, Geom.label(position=:right))
layer3 = layer(xintercept=[2cm], Geom.vline(color="orange"))

p1 = plot(layer1, layer2, layer3, Guide.title("Scale.x_continuous"))
p2 = plot(layer1, layer2, layer3, Scale.x_discrete, Guide.title("Scale.x_discrete"))
hstack(p1, p2)
```
![Plot04](https://user-images.githubusercontent.com/18226881/104824216-124f4d80-58a4-11eb-91d7-ec1472ff5f21.png)


