### PR TITLE
Added ability for intercept in geom.hair to take vector to function as lolipop

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ Each release typically has a number of minor bug fixes beyond what is listed her
  * Add "vertical" orientation for `Geom.ribbon` (#1513)
  * Support one-length aesthetics for `Geom.polygon` and `Geom.ribbon` (#1511)
  * Enable `color` grouping for `Geom.density2d` (#1508)
+ * Add ability for `intercept` to be a vector in `Geom.hair` to function as a lolipop chart (#1518)
 
 # Version 1.3.1
 

--- a/docs/src/gallery/geometries.md
+++ b/docs/src/gallery/geometries.md
@@ -271,13 +271,17 @@ hstack(p1,p2)
 
 ```@example
 using Gadfly
-set_default_plot_size(21cm, 8cm)
+set_default_plot_size(21cm, 16cm)
 x= 1:10
 s = [-1,-1,1,1,-1,-1,1,1,-1,-1]
 pa = plot(x=x, y=x.^2, Geom.hair, Geom.point)
 pb = plot(x=s.*(x.^2), y=x, color=string.(s),
           Geom.hair(orientation=:horizontal), Geom.point, Theme(key_position=:none))
-hstack(pa, pb)
+pc = plot(x=x, y=x.^2, Geom.hair(intercept=(x.^2)./2), Geom.point)
+pd = plot(x=s.*(x.^2), y=x, color=string.(s),
+          Geom.hair(orientation=:horizontal, intercept=s.*(x.^2)/2), Geom.point, 
+          Theme(key_position=:none))
+gridstack([pa pb; pc pd])
 ```
 
 

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -2004,10 +2004,18 @@ function apply_statistic(stat::HairStatistic,
                          aes::Gadfly.Aesthetics)
     if stat.orientation == :vertical
         aes.xend = aes.x
-        aes.yend = fill(stat.intercept, length(aes.y))
+        if length(stat.intercept) == length(aes.x)
+            aes.yend = stat.intercept
+        else
+            aes.yend = fill(stat.intercept, length(aes.y))
+        end
     else
         aes.yend = aes.y
-        aes.xend = fill(stat.intercept, length(aes.x))
+        if length(stat.intercept) == length(aes.x)
+            aes.xend = stat.intercept
+        else
+            aes.xend = fill(stat.intercept, length(aes.x))
+        end
     end
 end
 

--- a/test/testscripts/hair.jl
+++ b/test/testscripts/hair.jl
@@ -2,13 +2,17 @@
 
 using  Gadfly
 
-set_default_plot_size(6inch, 3inch)
+set_default_plot_size(6inch, 6inch)
 
 
 x= 1:10
 s = [-1,-1,1,1,-1,-1,1,1,-1,-1]
 pa = plot(x=x, y=x.^2, Geom.hair, Geom.point)
 pb = plot(x=s.*(x.^2), y=x, Geom.hair(orientation=:horizontal), Geom.point, color=string.(s), Theme(key_position=:none))
-hstack(pa, pb)
+pc = plot(x=x, y=x.^2, Geom.hair(intercept=(x.^2)./2), Geom.point)
+pd = plot(x=s.*(x.^2), y=x, color=string.(s),
+          Geom.hair(orientation=:horizontal, intercept=s.*(x.^2)/2), Geom.point, 
+          Theme(key_position=:none))
+gridstack([pa pb; pc pd])
 
 


### PR DESCRIPTION

Chainged Geom.hair
Documented hair as lolipop in geometries documentation
Added Geom.hair update as lolipop to news
Added tests for Geom.hair lolipop

<!-- Replace XXX with the issue number that this PR fixes, remove if there is no corresponding issue -->
Fixes #XXX

# Contributor checklist:

<!-- Make sure to complete all of these that apply -->

- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x] I've `squash`'ed or `fixup`'ed junk commits with git-rebase
- [ ] I've built the docs and confirmed these changes don't cause new errors


# Proposed changes
Use length check on `intercept` in `Geom.hair` to determine if it is same length as number of points want to draw hairs for.

If it is same length, don't fill end point vector, just use the supplied vector. 

![hair](https://user-images.githubusercontent.com/3414076/108433316-e572c980-7299-11eb-8bd0-58ea5bcaf0fe.png)


# Doc building issues
I've added it to the test files and above you can see the output, however when i try to build the documentation I get an error:
 `MethodError: no method matching isless(::Array{Float64,1}, ::Int64)`

Though it isn't the only `@example` block that gives some errors.
