### PR TITLE
Make plot layers & inner subplot layers consistent

### DIFF
--- a/src/geom/hvabline.jl
+++ b/src/geom/hvabline.jl
@@ -159,7 +159,7 @@ function render(geom::ABLineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
     if typeof(aes.y) <: Array{Function}
         lowx, highx = aes.xmin[1], aes.xmax[1]
     else
-        lowx, highx = extrema(aes.x)
+        lowx, highx = extrema(aes.x[isfinite.(aes.x)])
     end
 
     # extending the line to width 3 times x-range of data should be enough

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1695,29 +1695,30 @@ function apply_statistic(stat::ViolinStatistic,
 
     isa(aes.y[1], Real) || error("Kernel density estimation only works on Real types.")
 
-    grouped_y = Dict(1=>aes.y)
-    grouped_color = Dict{Int, Gadfly.ColorOrNothing}(1=>nothing)
-    ux = unique(aes.x)
-    uxflag = length(ux) < length(aes.x)
-    colorflag = aes.color != nothing
+    colorflag = aes.color !== nothing
+    aes_x = aes.x==nothing ? [1] : aes.x
+    aes_color = colorflag ? aes.color : [nothing]
+    XT, CT, YT = eltype(aes_x), eltype(aes_color), eltype(aes.y)
+    groups = collect((Tuple{XT, CT}), Compose.cyclezip(aes_x, aes_color))
+    ugroups = unique(groups)
+    nugroups = length(ugroups)
 
-    uxflag && (grouped_y = Dict(x=>aes.y[aes.x.==x] for x in ux))
+    grouped_y = if nugroups==1
+        Dict(ugroups[1]=>aes.y)
+    else
+        Dict(g=>aes.y[groups.==[g]]  for g in ugroups)
+    end
 
-    grouped_color = (colorflag ? Dict(x=>first(aes.color[aes.x.==x]) for x in ux) : 
-        uxflag && Dict(x=>nothing for x in ux) )
+    aes.x, aes.y, aes.width = XT[], Float64[], Float64[]
+    colors = CT[]
 
-    aes.x     = Array{Float64}(undef, 0)
-    aes.y     = Array{Float64}(undef, 0)
-    aes.width = Array{Float64}(undef, 0)
-    colors = eltype(aes.color)[]
-
-    for (x, ys) in grouped_y
+    for ((x, c), ys) in grouped_y
         window = stat.n > 1 ? KernelDensity.default_bandwidth(ys) : 0.1
         f = KernelDensity.kde(ys, bandwidth=window, npoints=stat.n)
         append!(aes.x, fill(x, length(f.x)))
         append!(aes.y, f.x)
         append!(aes.width, f.density)
-        append!(colors, fill(grouped_color[x], length(f.x)))
+        append!(colors, fill(c, length(f.x)))
     end
 
     colorflag && (aes.color = colors)


### PR DESCRIPTION

- [ ] I've run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors


### This PR:

- makes the `layer.statistics` field of `plot(layer(...))` and the inner layers of `Geom.subplot_grid()` consistent (fixes #1516)
- updates `Stat.violin` as needed
- an open question from this PR is what should be in the `layer.statistics` field of the _outer_ layer of `layer(Geom.subplot_grid(layer(...)))`. Note that this should not necessarily be the same as 
the `statistics` field of the inner layers, which are clearly defined by this PR.  
E.g. the outer layer of `Geom.subplot_grid` could contain statistics which modify aesthetics such as `:xgroup` and `:ygroup`, but
no such statistics have been developed yet for Gadfly.

### Example 
(now `p2` shows same behaviour as `p1` from OP in #1516):
```julia
p2 = Geom.subplot_grid(Stat.smooth, Geom.ribbon)
p2.statistics   # StatisticELement[]
p2.layers[1].statistics # StatisticElement[Stat.smooth()]
```

- Note in this PR, the fields `p1.statistics` and `p2.statistics` have not been deprecated, because they may be useful for developers.

