### PR TITLE
Set version to 1.3.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 This is a log of major changes in Gadfly between releases. It is not exhaustive.
 Each release typically has a number of minor bug fixes beyond what is listed here.
 
-# Version 1.x
+# Version 1.3.2
 
  * Add `Stat.quantile_bars` (#1521)
  * Add "vertical" orientation for `Geom.ribbon` (#1513)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Gadfly"
 uuid = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
-version = "1.3.1"
+version = "1.3.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
As stated in https://github.com/GiovineItalia/Gadfly.jl/pull/1521, I would like to use the quantile bars in a paper and it would be great if I can just use a registered Gadfly version instead of `master`. Therefore, I propose to bump the version.

Also, this bump would finally show the favicon in the stable documentation, which I introduced almost 5 months ago (https://github.com/GiovineItalia/Gadfly.jl/pull/1488).