### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0' 
+          - '1.4' 
           - '1' # Latest stable release of Julia. 
           - nightly
         os:


### PR DESCRIPTION
Just another attempt to bump the minimum Julia version being tested, as was also discussed [here](https://github.com/GiovineItalia/Gadfly.jl/pull/1496#issuecomment-727980008). Julia 1.0 is now broken for months and I don't see how that would change.

In effect, the tests for Julia 1.0 goes as follows:
1. Fail after a few seconds on a incompatible requirement; not executing any test.
2. Show a red cross at all places in the GitHub interface, introducing confusion for everyone.
3. Send an email to the creator of a pull request that the PR failed **even though all tests pass**.

Note that this test doesn't mean that people on Julia 1.0 cannot install Gadfly anymore. It just means that it's not tested in CI here.

As another argument. I think that this would help Gadfly move forward more easily. That is in line with some of Lehman's laws of software evolution ([1980](https://en.wikipedia.org/wiki/Lehman's_laws_of_software_evolution)):

> 1 an E-type system [software that performs some real-world activity] must be continually adapted or it becomes progressively less satisfactory.
> 6 the functional content of an E-type system must be continually increased to maintain user satisfaction over its lifetime.
> 7 the quality of an E-type system will appear to be declining unless it is rigorously maintained and adapted to operational environment changes.