### PR TITLE
make Gadfly "relocatable" by not loading files at runtime

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -41,11 +41,6 @@ export Plot, Layer, Theme, Col, Row, Scale, Coord, Geom, Guide, Stat, Shape, ren
 export SVGJS, SVG, PGF, PNG, PS, PDF, draw, inch, mm, cm, px, pt, color, @colorant_str, vstack, hstack, title, gridstack
 
 
-function link_terminalextensions()
-    @debug "Loading TerminalExtensions support into Gadfly"
-    include("terminalextensions.jl")
-end
-
 function __init__()
     # Define an XML namespace for custom attributes
     Compose.xmlns["gadfly"] = "http://www.gadflyjl.org/ns"
@@ -63,8 +58,8 @@ function __init__()
 
     insert!(Base.Multimedia.displays, findlast(x->(x isa TextDisplay || x isa REPL.REPLDisplay), Base.Multimedia.displays)+1, GadflyDisplay())
 
-    @require DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0" link_dataframes()
-    @require TerminalExtensions="d3a6a179-465e-5219-bd3e-0137f7fd17c7" link_terminalextensions()
+    @require DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0" include("dataframes.jl")
+    @require TerminalExtensions="d3a6a179-465e-5219-bd3e-0137f7fd17c7" include("terminalextensions.jl")
 end
 
 

--- a/src/dataframes.jl
+++ b/src/dataframes.jl
@@ -1,3 +1,5 @@
+@debug "Loading DataFrames support into Gadfly"
+
 using .DataFrames
 
 function meltdata(U::AbstractDataFrame, colgroups::Vector{Col.GroupedColumn})

--- a/src/mapping.jl
+++ b/src/mapping.jl
@@ -233,7 +233,3 @@ function evalmapping!(mapping::Dict, data_source, data::Data)
     return _evalmapping!(mapping, transformed_data_source, data)
 end
 
-function link_dataframes()
-    @debug "Loading DataFrames support into Gadfly"
-    include("dataframes.jl")
-end

--- a/src/terminalextensions.jl
+++ b/src/terminalextensions.jl
@@ -1,3 +1,5 @@
+@debug "Loading TerminalExtensions support into Gadfly"
+
 using .TerminalExtensions
 
 function putatend(idisplay, display::iTerm2.InlineDisplay)


### PR DESCRIPTION
Gadfly currently loads two source files at runtime using Requires to add extra functionality when some packages are loaded. One issue with this is that if you compile Gadfly into a sysimage and move the sysimage somewhere else, these files will not exist and Gadfly will not work. An example of when this happens is when using PackageCompiler (https://github.com/JuliaLang/PackageCompiler.jl/issues/498).

Requires.jl has since https://github.com/JuliaPackaging/Requires.jl/pull/85 the capability of storing the source code that would be included inside the package. When the `@requires` block runs, there is then no need to actually read the file for the code, instead, the code saved inside the package is used. However, this functionality only works if the `@requires` block is a simple `include` statement. Therefore, this PR does the small changes to allow this to work and allowed Gadfly to be used with sysimage and not have those sysimages depend on paths on the local machine.