### PR TITLE
Add note to tutorial.md explaining pain point

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -73,6 +73,10 @@ Now we have the following charming little SVG image.
 p # hide
 ```
 
+If some of the text in this image is overlapping other text, your browser
+likely has a minimum font size set. You will need to unset this option for
+the plots to render correctly in your web browser.
+
 If you are working at the REPL, a quicker way to see the image is to omit
 the semi-colon trailing `plot`.  This automatically renders the image to
 your default multimedia display, typically an internet browser.  No need


### PR DESCRIPTION
Add note explaining that a minimum font size in your browser can cause improper text rendering (as happened to me in issue #1532 the other day).

Hopefully this will help others avoid/resolve this pain point that I hit.

# Contributor checklist:

Most of these items don't apply since I'm just proposing a minor addition to the documentation

# Proposed changes

- Minor addition to documentation in tutorial (explained above)
