### PR TITLE
Disable Codecov comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
In https://github.com/GiovineItalia/Gadfly.jl/pull/1538, Codecov comments that some coverage has changed with about 2 percent even though the PR doesn't touch any Julia files.

This PR disables the comments, which is identical to what is used over at [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl). The link in the README stays and will keep functioning.