### PR TITLE
Fix free_[xy]_axis not working with some geometries. Fixes #1557

### DIFF
--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -408,19 +408,22 @@ function by_xy_group(aes::T, xgroup, ygroup,
 end
 
 function inherit(a::Aesthetics, b::Aesthetics;
-                 clobber=[])
+                 clobber=[], preserve=[])
     acopy = copy(a)
-    inherit!(acopy, b, clobber=clobber)
+    inherit!(acopy, b, clobber=clobber, preserve=preserve)
     return acopy
 end
 
 function inherit!(a::Aesthetics, b::Aesthetics;
-                  clobber=[])
+                  clobber=[], preserve=[])
     clobber_set = Set{Symbol}(clobber)
+    preserve_set = Set{Symbol}(preserve)
     for field in valid_aesthetics
         aval = getfield(a, field)
         bval = getfield(b, field)
-        if field in clobber_set
+        if field in preserve_set
+            continue
+        elseif field in clobber_set
             setfield!(a, field, bval)
         elseif aval === missing || aval === nothing || aval === string || aval == showoff
             setfield!(a, field, bval)

--- a/src/geom/subplot.jl
+++ b/src/geom/subplot.jl
@@ -206,7 +206,7 @@ function render(geom::SubplotGrid, theme::Gadfly.Theme,
         for j in 1:m
             col_aes = Gadfly.concat([layer_aes_grid[k][i, j]
                                      for i in 1:n, k in 1:length(geom.layers)]...)
-            Gadfly.inherit!(col_aes, geom_aes)
+            Gadfly.inherit!(col_aes, geom_aes, preserve=[:xviewmin, :xviewmax])
             Stat.apply_statistic(Stat.xticks(), scales, coord, col_aes)
 
             aes_grid[:, j] .= [col_aes]
@@ -217,11 +217,11 @@ function render(geom::SubplotGrid, theme::Gadfly.Theme,
         for i in 1:n
             row_aes = Gadfly.concat([layer_aes_grid[k][i, j]
                                      for j in 1:m, k in 1:length(geom.layers)]...)
-            Gadfly.inherit!(row_aes, geom_aes)
+            Gadfly.inherit!(row_aes, geom_aes, preserve=[:yviewmin, :yviewmax])
             Stat.apply_statistic(Stat.yticks(), scales, coord, row_aes)
 
             for j in 1:m
-                aes_grid[i, j] = Gadfly.inherit(row_aes, aes_grid[i, j])
+                aes_grid[i, j] = Gadfly.inherit(row_aes, aes_grid[i, j], preserve=[:yviewmin, :yviewmax])
             end
         end
     end


### PR DESCRIPTION
Fixes issue #1557 by preventing the `yviewmax` aesthetic from getting set to the plot-wise value, preserving the column or row value.