### PR TITLE
refactor to use test/Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,14 +31,12 @@ Showoff = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Cairo = "0.7, 0.8, 1.0"
 CategoricalArrays = "0.8, 0.9, 0.10"
 Colors = "0.9, 0.10, 0.11, 0.12"
 Compose = "0.9"
 Contour = "0.5"
 CoupledFields = "0.1, 0.2"
 DataAPI = "1.6"
-DataFrames = "0.21, 0.22"
 DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18"
 Distributions = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 DocStringExtensions = "0.7, 0.8"
@@ -50,20 +48,6 @@ Juno = "0.7, 0.8"
 KernelDensity = "0.5, 0.6"
 Loess = "0.4, 0.5"
 Measures = "0.3"
-RDatasets = "0.6, 0.7"
 Requires = "0.5, 1.0"
 Showoff = "0.2, 0.3, 1.0"
-Unitful = "0.15, 0.16, 0.17, 0.18, 1.0"
 julia = "1"
-
-[extras]
-Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
-RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
-
-[targets]
-test = ["Cairo", "DataFrames", "DelimitedFiles", "LibGit2", "RDatasets", "Test", "Unitful"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -18,6 +18,6 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Cairo = "0.7, 0.8, 1.0"
-DataFrames = "0.21, 0.22"
+DataFrames = "0.21, 0.22, 1"
 RDatasets = "0.6, 0.7"
 Unitful = "0.15, 0.16, 0.17, 0.18, 1.0"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,23 @@
+[deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[compat]
+Cairo = "0.7, 0.8, 1.0"
+DataFrames = "0.21, 0.22"
+RDatasets = "0.6, 0.7"
+Unitful = "0.15, 0.16, 0.17, 0.18, 1.0"


### PR DESCRIPTION
this seemingly simple change fails for me locally with julia 1.7.3.  hoping it works with CI:

```
(Gadfly) pkg> test
     Testing Gadfly
┌ Warning: Could not use exact versions of packages in manifest, re-resolving
└ @ Pkg.Operations /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.7/Pkg/src/Operations.jl:1488
      Status `/private/var/folders/yn/v3cn9q9x50x85l5x3xcspzssmsxs4y/T/jl_OQFew3/Project.toml`
  [159f3aea] Cairo v1.0.5
  [a93c6f00] DataFrames v0.22.7
  [c91e804a] Gadfly v1.3.4 `~/.julia/dev/Gadfly`
  [ce6b1742] RDatasets v0.7.7
  [1986cc42] Unitful v1.11.0
  [8bb1440f] DelimitedFiles `@stdlib/DelimitedFiles`
  [76f85450] LibGit2 `@stdlib/LibGit2`
  [8dfed614] Test `@stdlib/Test`
      Status `/private/var/folders/yn/v3cn9q9x50x85l5x3xcspzssmsxs4y/T/jl_OQFew3/Manifest.toml`
  [621f4979] AbstractFFTs v1.2.1
  [79e6a3ab] Adapt v3.3.3
  [13072b0f] AxisAlgorithms v1.0.1
  [336ed68f] CSV v0.10.4
  [159f3aea] Cairo v1.0.5
  [49dc2e85] Calculus v0.5.1
  [324d7699] CategoricalArrays v0.9.7
  [d360d2e6] ChainRulesCore v1.15.1
  [9e997f8a] ChangesOfVariables v0.1.3
  [944b1d66] CodecZlib v0.7.0
  [3da002f7] ColorTypes v0.11.4
  [5ae59095] Colors v0.12.8
  [34da2185] Compat v3.45.0
  [a81c6b42] Compose v0.9.4
  [187b0558] ConstructionBase v1.4.0
  [d38c429a] Contour v0.5.7
  [7ad07ef1] CoupledFields v0.2.0
  [a8cc5b0e] Crayons v4.1.1
  [9a962f9c] DataAPI v1.10.0
  [a93c6f00] DataFrames v0.22.7
  [864edb3b] DataStructures v0.18.13
  [e2d170a0] DataValueInterfaces v1.0.0
  [b429d917] DensityInterface v0.4.0
  [b4f34e82] Distances v0.10.7
  [31c24e10] Distributions v0.25.65
  [ffbed154] DocStringExtensions v0.8.6
  [fa6b7ba4] DualNumbers v0.6.8
  [e2ba6199] ExprTools v0.1.8
  [7a1cc6ca] FFTW v1.5.0
  [5789e2e9] FileIO v1.14.0
  [48062228] FilePathsBase v0.9.18
  [1a297f60] FillArrays v0.13.2
  [53c48c17] FixedPointNumbers v0.8.4
  [59287772] Formatting v0.4.2
  [c91e804a] Gadfly v1.3.4 `~/.julia/dev/Gadfly`
  [a2bd30eb] Graphics v1.1.2
  [42e2da0e] Grisu v1.0.2
  [a1b4810d] Hexagons v0.2.0
  [34004b35] HypergeometricFunctions v0.3.10
  [9b13fd28] IndirectArrays v1.0.0
  [842dd82b] InlineStrings v1.1.4
  [a98d9a8b] Interpolations v0.13.6
  [3587e190] InverseFunctions v0.1.7
  [41ab1584] InvertedIndices v1.1.0
  [92d709cd] IrrationalConstants v0.1.1
  [c8e1da08] IterTools v1.4.0
  [82899510] IteratorInterfaceExtensions v1.0.0
  [692b3bcd] JLLWrappers v1.4.1
  [682c06a0] JSON v0.21.3
  [e5e0dc1b] Juno v0.8.4
  [5ab0869b] KernelDensity v0.6.3
  [4345ca2d] Loess v0.5.4
  [2ab3a3ac] LogExpFunctions v0.3.15
  [1914dd2f] MacroTools v0.5.9
  [442fdcdd] Measures v0.3.1
  [e89f7d12] Media v0.5.0
  [e1d29d7a] Missings v0.4.5
  [78c3b35d] Mocking v0.7.3
  [77ba4419] NaNMath v1.0.0
  [6fe1bfb0] OffsetArrays v1.12.7
  [bac558e1] OrderedCollections v1.4.1
  [90014a1f] PDMats v0.11.16
  [69de0a69] Parsers v2.3.2
  [2dfb63ee] PooledArrays v1.4.2
  [21216c6a] Preferences v1.3.0
  [08abe8d2] PrettyTables v0.11.1
  [1fd47b50] QuadGK v2.4.2
  [df47a6cb] RData v0.8.3
  [ce6b1742] RDatasets v0.7.7
  [c84ed2f1] Ratios v0.4.3
  [3cdcf5f2] RecipesBase v1.2.1
  [189a3867] Reexport v1.2.2
  [ae029012] Requires v1.3.0
  [79098fc4] Rmath v0.7.0
  [91c51154] SentinelArrays v1.3.13
  [992d4aef] Showoff v1.0.3
  [a2af1166] SortingAlgorithms v0.3.1
  [276daf66] SpecialFunctions v2.1.7
  [90137ffa] StaticArrays v1.5.0
  [1e83bf80] StaticArraysCore v1.0.1
  [82ae8749] StatsAPI v1.4.0
  [2913bbd2] StatsBase v0.33.18
  [4c63d2b9] StatsFuns v1.0.1
  [856f2bd8] StructTypes v1.8.1
  [3783bdb8] TableTraits v1.0.1
  [bd369af6] Tables v1.7.0
  [f269a46b] TimeZones v1.8.0
  [3bb67fe8] TranscodingStreams v0.9.6
  [1986cc42] Unitful v1.11.0
  [ea10d353] WeakRefStrings v1.4.2
  [efce3f68] WoodburyMatrices v0.5.5
  [6e34b625] Bzip2_jll v1.0.8+0
  [83423d85] Cairo_jll v1.16.1+1
  [2e619515] Expat_jll v2.4.8+0
  [f5851436] FFTW_jll v3.3.10+0
  [a3f928ae] Fontconfig_jll v2.13.93+0
  [d7e528f0] FreeType2_jll v2.10.4+0
  [559328eb] FriBidi_jll v1.0.10+0
  [78b55507] Gettext_jll v0.21.0+0
  [7746bdde] Glib_jll v2.68.3+2
  [3b182d85] Graphite2_jll v1.3.14+0
  [2e76f6c2] HarfBuzz_jll v2.8.1+1
  [1d5cc7b8] IntelOpenMP_jll v2018.0.3+2
  [dd4b983a] LZO_jll v2.10.1+0
  [e9f186c6] Libffi_jll v3.2.2+1
  [d4300ac3] Libgcrypt_jll v1.8.7+0
  [7add5ba3] Libgpg_error_jll v1.42.0+0
  [94ce4f54] Libiconv_jll v1.16.1+1
  [4b2f31a3] Libmount_jll v2.35.0+0
  [38a345b3] Libuuid_jll v2.36.0+0
  [856f044c] MKL_jll v2022.0.0+0
  [efe28fd5] OpenSpecFun_jll v0.5.5+0
  [2f80f16e] PCRE_jll v8.44.0+0
  [36c8627f] Pango_jll v1.50.3+0
  [30392449] Pixman_jll v0.40.1+0
  [f50d1b31] Rmath_jll v0.3.0+0
  [02c8fc9c] XML2_jll v2.9.14+0
  [aed1982a] XSLT_jll v1.1.34+0
  [4f6342f7] Xorg_libX11_jll v1.6.9+4
  [0c0b7dd1] Xorg_libXau_jll v1.0.9+4
  [a3789734] Xorg_libXdmcp_jll v1.1.3+4
  [1082639a] Xorg_libXext_jll v1.3.4+4
  [ea2f1a96] Xorg_libXrender_jll v0.9.10+4
  [14d82f49] Xorg_libpthread_stubs_jll v0.1.0+3
  [c7cfdc94] Xorg_libxcb_jll v1.13.0+3
  [c5fb5394] Xorg_xtrans_jll v1.4.0+3
  [b53b4c65] libpng_jll v1.6.38+0
  [0dad84c5] ArgTools `@stdlib/ArgTools`
  [56f22d72] Artifacts `@stdlib/Artifacts`
  [2a0f44e3] Base64 `@stdlib/Base64`
  [ade2ca70] Dates `@stdlib/Dates`
  [8bb1440f] DelimitedFiles `@stdlib/DelimitedFiles`
  [8ba89e20] Distributed `@stdlib/Distributed`
  [f43a241f] Downloads `@stdlib/Downloads`
  [7b1f6079] FileWatching `@stdlib/FileWatching`
  [9fa8497b] Future `@stdlib/Future`
  [b77e0a4c] InteractiveUtils `@stdlib/InteractiveUtils`
  [4af54fe1] LazyArtifacts `@stdlib/LazyArtifacts`
  [b27032c2] LibCURL `@stdlib/LibCURL`
  [76f85450] LibGit2 `@stdlib/LibGit2`
  [8f399da3] Libdl `@stdlib/Libdl`
  [37e2e46d] LinearAlgebra `@stdlib/LinearAlgebra`
  [56ddb016] Logging `@stdlib/Logging`
  [d6f4376e] Markdown `@stdlib/Markdown`
  [a63ad114] Mmap `@stdlib/Mmap`
  [ca575930] NetworkOptions `@stdlib/NetworkOptions`
  [44cfe95a] Pkg `@stdlib/Pkg`
  [de0858da] Printf `@stdlib/Printf`
  [9abbd945] Profile `@stdlib/Profile`
  [3fa0cd96] REPL `@stdlib/REPL`
  [9a3f8284] Random `@stdlib/Random`
  [ea8e919c] SHA `@stdlib/SHA`
  [9e88b42a] Serialization `@stdlib/Serialization`
  [1a1011a3] SharedArrays `@stdlib/SharedArrays`
  [6462fe0b] Sockets `@stdlib/Sockets`
  [2f01184e] SparseArrays `@stdlib/SparseArrays`
  [10745b16] Statistics `@stdlib/Statistics`
  [4607b0f0] SuiteSparse `@stdlib/SuiteSparse`
  [fa267f1f] TOML `@stdlib/TOML`
  [a4e569a6] Tar `@stdlib/Tar`
  [8dfed614] Test `@stdlib/Test`
  [cf7118a7] UUIDs `@stdlib/UUIDs`
  [4ec0a83e] Unicode `@stdlib/Unicode`
  [e66e0078] CompilerSupportLibraries_jll `@stdlib/CompilerSupportLibraries_jll`
  [deac9b47] LibCURL_jll `@stdlib/LibCURL_jll`
  [29816b5a] LibSSH2_jll `@stdlib/LibSSH2_jll`
  [c8ffd9c3] MbedTLS_jll `@stdlib/MbedTLS_jll`
  [14a3606d] MozillaCACerts_jll `@stdlib/MozillaCACerts_jll`
  [4536629a] OpenBLAS_jll `@stdlib/OpenBLAS_jll`
  [05823500] OpenLibm_jll `@stdlib/OpenLibm_jll`
  [83775a58] Zlib_jll `@stdlib/Zlib_jll`
  [8e850b90] libblastrampoline_jll `@stdlib/libblastrampoline_jll`
  [8e850ede] nghttp2_jll `@stdlib/nghttp2_jll`
  [3f19e933] p7zip_jll `@stdlib/p7zip_jll`
     Testing Running tests...
ERROR: LoadError: ArgumentError: Package Dates not found in current path:
- Run `import Pkg; Pkg.add("Dates")` to install the Dates package.

Stacktrace:
 [1] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:967
 [2] include(fname::String)
   @ Base.MainInclude ./client.jl:451
 [3] top-level scope
   @ none:6
in expression starting at /Users/arthurb/.julia/dev/Gadfly/test/runtests.jl:8
ERROR: Package Gadfly errored during testing
```