### PR TITLE
add alpha aesthetic to Geom.line

### DIFF
--- a/test/testscripts/line_alpha.jl
+++ b/test/testscripts/line_alpha.jl
@@ -1,0 +1,19 @@
+using Gadfly, DataFrames
+set_default_plot_size(6inch, 3inch)
+
+test = DataFrame(x=[1:100; 1:100],
+                 y=[1:100; 100:-1:1],
+                 z = repeat(["a", "b"], inner = 100));
+
+p1 = plot(test,
+          Geom.line,
+          x=:x, y=:y, color = :z,
+          alpha=[0.1]);
+
+p2 = plot(test,
+          Geom.line,
+          x=:x, y=:y,
+          alpha = :z,
+          Theme(alphas=[1.0,0.5]));
+
+hstack(p1,p2)


### PR DESCRIPTION
fixes https://github.com/GiovineItalia/Gadfly.jl/issues/1589

```
julia> using Gadfly, DataFrames

julia> test = DataFrame(
           x=1:100,
           y=rand(100),
           z = repeat(["a", "b"], outer = 50));

julia> plot(test,
            x=:x,
            y=:y,
            color = :z,
            Geom.line,
            alpha=[0.1])

julia> plot(test,
            x=:x,
            y=:y,
            alpha = :z,
            Geom.line,
            Theme(alphas=[1.0,0.5]))
```
<img width="523" alt="Screen Shot 2022-12-11 at 10 59 25 AM" src="https://user-images.githubusercontent.com/1538268/206914265-49d4f705-3860-4b77-a3a2-3d5c7b51a9dd.png">

<img width="526" alt="Screen Shot 2022-12-11 at 10 59 32 AM" src="https://user-images.githubusercontent.com/1538268/206914270-ac4bc929-0da1-479b-9af3-5bbb91d3c9cd.png">

