### PR TITLE
Geom.ribbon with group aesthetic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,15 @@
 This is a log of major changes in Gadfly between releases. It is not exhaustive.
 Each release typically has a number of minor bug fixes beyond what is listed here.
 
+# Version 1.3.x
+
+ * Enable `group` aesthetic for `Geom.ribbon` (#1605)
+
+
 # Version 1.3.3
 
- * Add support for Showoff 1.0 (#1522)
  * Add support for CategoricalArrays 0.10 (#1537)
+ * Add support for Showoff 1.0 (#1522)
 
 # Version 1.3.2
 

--- a/docs/src/gallery/geometries.md
+++ b/docs/src/gallery/geometries.md
@@ -479,14 +479,14 @@ using Gadfly, DataFrames, Distributions
 set_default_plot_size(21cm, 8cm)
 X, x = [cos.(0:0.1:20) sin.(0:0.1:20)], -4:0.1:4
 Da = [DataFrame(x=0:0.1:20, y=X[:,j], ymin=X[:,j].-0.5, ymax=X[:,j].+0.5, f="$f")  for (j,f) in enumerate(["cos","sin"])]
-Db = [DataFrame(x=x, ymax=pdf.(Normal(μ),x), ymin=0.0, u="μ=$μ") for μ in [-1,1] ]
+Db = [DataFrame(x=x, ymax=pdf.(Normal(μ),x), u="μ=$μ") for μ in [-1,1] ]
 
 # In the line below, 0.6 is the color opacity
 p1 = plot(vcat(Da...), x=:x, y=:y, ymin=:ymin, ymax=:ymax, color=:f,
     Geom.line, Geom.ribbon, alpha=[0.6])
 p2 = plot(Da[1], x=:y, y=:x, xmin=:ymin, xmax=:ymax, color=[colorant"red"],
     Geom.path, Geom.ribbon)
-p3 = plot(vcat(Db...), x = :x, y=:ymax, ymin = :ymin, ymax = :ymax,
+p3 = plot(vcat(Db...), x = :x, y=:ymax, ymin=[0.0], ymax = :ymax,
     color = :u, alpha=:u, Theme(alphas=[0.8,0.2]),
     Geom.line, Geom.ribbon, Guide.ylabel("Density"),
     Guide.colorkey(title="", pos=[2.1,0.6]), Guide.title("Parametric PDF"))

--- a/docs/src/gallery/statistics.md
+++ b/docs/src/gallery/statistics.md
@@ -18,10 +18,10 @@ hstack(p1,p2)
 using DataFrames, Gadfly, Distributions
 set_default_plot_size(21cm, 8cm)
 x = -4:0.1:4
-Da = [DataFrame(x=x, ymax=pdf.(Normal(μ),x), ymin=0.0, u="μ=$μ") for μ in [-1,1]]
+Da = [DataFrame(x=x, ymax=pdf.(Normal(μ),x), u="μ=$μ") for μ in [-1,1]]
 Db = [DataFrame(x=randn(200).+μ, u="μ=$μ") for μ in [-1,1]]
 
-p1 = plot(vcat(Da...), x=:x, y=:ymax, ymin=:ymin, ymax=:ymax, color=:u, 
+p1 = plot(vcat(Da...), x=:x, y=:ymax, ymin=[0.0], ymax=:ymax, color=:u, 
     Geom.line, Geom.ribbon, Guide.ylabel("Density"), Theme(alphas=[0.6]),
     Guide.colorkey(title="", pos=[2.5,0.6]), Guide.title("Parametric PDF")
 )

--- a/src/geom/ribbon.jl
+++ b/src/geom/ribbon.jl
@@ -17,7 +17,7 @@ const ribbon = RibbonGeometry
 
 default_statistic(geom::RibbonGeometry) = geom.default_statistic
 
-element_aesthetics(::RibbonGeometry) = [:x, :ymin, :ymax, :y, :xmin, :xmax, :color, :linestyle, :alpha]
+element_aesthetics(::RibbonGeometry) = [:x, :ymin, :ymax, :y, :xmin, :xmax, :color, :linestyle, :alpha, :group]
 
 function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     orientation = if isempty(Gadfly.undefined_aesthetics(aes, :x, :ymin, :ymax))
@@ -35,7 +35,7 @@ function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
     end
 
     Gadfly.assert_aesthetics_defined("Geom.ribbon", aes, var, minvar, maxvar)
-    Gadfly.assert_aesthetics_equal_length("Geom.ribbon", aes, var, minvar, maxvar)
+    Gadfly.assert_aesthetics_equal_length("Geom.ribbon", aes, var, maxvar)
 
     vals = getfield(aes, var)
     maxvals = getfield(aes, maxvar)
@@ -45,31 +45,32 @@ function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
     default_aes.linestyle = [1]
     default_aes.color = Colorant[theme.default_color]
     default_aes.alpha = [1]
+    default_aes.group = IndirectArray([1])
     aes = inherit(aes, default_aes)
 
-    aes_vals, aes_minvals, aes_maxvals, aes_color, aes_linestyle, aes_alpha =
-         concretize(vals, minvals, maxvals, aes.color, aes.linestyle, aes.alpha)
-    XT, CT, LST, AT = eltype(aes_vals), eltype(aes_color), eltype(aes_linestyle), eltype(aes_alpha)
-    YT = eltype(aes_minvals)
-    groups = collect((Tuple{CT, LST, AT}), Compose.cyclezip(aes_color, aes_linestyle, aes_alpha))
+    aes_vals, aes_minvals, aes_maxvals, aes_color, aes_linestyle, aes_alpha, aes_group =
+         concretize(vals, minvals, maxvals, aes.color, aes.linestyle, aes.alpha, aes.group)
+    CT, LST, AT, GT = eltype(aes_color), eltype(aes_linestyle), eltype(aes_alpha), eltype(aes_group)
+    XT, YT = eltype(aes_vals), eltype(aes_minvals)
+    groups = collect((Tuple{CT, LST, AT, GT}), Compose.cyclezip(aes_color, aes_linestyle, aes_alpha, aes_group))
     ugroups = unique(groups)
     nugroups = length(ugroups)
     
     V = Vector{Tuple{XT, YT}}
-    K = Tuple{CT, LST, AT}
+    K = Tuple{CT, LST, AT, GT}
 
     max_points = Dict{K, V}(g=>V[] for g in ugroups)
     min_points = Dict{K, V}(g=>V[] for g in ugroups)
     orderf = first
     if orientation==:vertical
-        for (x, ymin, ymax, c, ls, a) in Compose.cyclezip(aes_vals, aes_minvals, aes_maxvals, aes_color, aes_linestyle, aes_alpha)
-            push!(max_points[(c,ls,a)], (x, ymax))
-            push!(min_points[(c,ls,a)], (x, ymin))
+        for (x, ymin, ymax, c, ls, a, g) in Compose.cyclezip(aes_vals, aes_minvals, aes_maxvals, aes_color, aes_linestyle, aes_alpha, aes_group)
+            push!(max_points[(c,ls,a,g)], (x, ymax))
+            push!(min_points[(c,ls,a,g)], (x, ymin))
         end
     else
-        for (x, ymin, ymax, c, ls, a) in Compose.cyclezip(aes_vals, aes_minvals, aes_maxvals, aes_color, aes_linestyle, aes_alpha)
-            push!(max_points[(c,ls,a)], (ymax, x))
-            push!(min_points[(c,ls,a)], (ymin, x))
+        for (x, ymin, ymax, c, ls, a, g) in Compose.cyclezip(aes_vals, aes_minvals, aes_maxvals, aes_color, aes_linestyle, aes_alpha, aes_group)
+            push!(max_points[(c,ls,a,g)], (ymax, x))
+            push!(min_points[(c,ls,a,g)], (ymin, x))
         end
         orderf = last
     end
@@ -90,7 +91,7 @@ function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
     alpha_discrete  = AT <: Int
     linestyle_discrete = LST <: Int
 
-    for (i, (c,ls,a)) in enumerate(kys)
+    for (i, (c,ls,a,g)) in enumerate(kys)
         classes[i] = svg_color_class_from_label(aes.color_label([c])[1])
         colors[i] = parse_colorant(theme.lowlight_color(c))
         linestyles[i] = linestyle_discrete ? get_stroke_vector(theme.line_style[mod1(ls, linestyle_palette_length)]) : get_stroke_vector(ls)


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] I've run the regression and doc tests

### This PR
- Enables the `group` aesthetic for `Geom.ribbon`
- I need this for my next PR (and will add a test then)

### Example
```julia
x = -4:0.1:4
Db = reduce(vcat, [DataFrame(x=x, ymax=pdf.(Normal(μ),x), u="μ=$μ") for μ in [-1,1]])
plot(Db, x=:x, y=:ymax, ymin=[0.0], ymax=:ymax,
    group=:u, alpha=[0.5], Geom.line, Geom.ribbon, 
    Guide.ylabel("Density"), Guide.title("Parametric PDF"))
```

![ribbon_group](https://user-images.githubusercontent.com/18226881/212091573-ec70cea5-c47c-4997-8736-6ab010212a0b.png)

