### PR TITLE
Stat.unidistribution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ Each release typically has a number of minor bug fixes beyond what is listed her
 
 # Version 1.3.x
 
+ * Add `Stat.unidistribution` (#1606)
  * Enable `group` aesthetic for `Geom.ribbon` (#1605)
 
 

--- a/docs/src/gallery/statistics.md
+++ b/docs/src/gallery/statistics.md
@@ -159,6 +159,31 @@ plot(x=rand(25), y=rand(25), Stat.step, Geom.line)
 ```
 
 
+## [`Stat.unidistribution`](@ref)
+
+```@example
+using DataFrames, Gadfly, Distributions
+using Gadfly: w,h
+set_default_plot_size(21cm, 8cm)
+D = DataFrame(Dist=["Prior", "Posterior"],  
+    Density=[Normal(-0.22, 0.02), Normal(-0.29, 0.015)])
+
+xcoord = Coord.cartesian(xmin=-0.4, xmax=-0.1)
+gck = Guide.colorkey(title="", pos=[0.5w, -0.4h])
+p1 = plot(D, y=:Density, color=:Dist, Guide.title("color=:Dist"), gck,
+    layer(Stat.unidistribution, Geom.line, Geom.ribbon, alpha=[0.8]), xcoord)
+p2 = plot(D, y=:Density, color=:Dist, layer(Stat.unidistribution, Geom.line),
+    layer(Stat.unidistribution([[0.0001, 0.05], [0.95, 0.9999]]), Geom.ribbon),
+    Guide.ylabel(nothing), Guide.title("color=:Dist"), gck)
+p3 = plot(D, y=:Density, group=:Dist, xcoord, gck,
+    layer(Stat.unidistribution([[0.0001, 0.1],[0.1, 0.9], [0.9, 0.9999]]), Geom.ribbon, alpha=[0.8]),
+    Scale.color_discrete_manual("orange", "yellow", "coral"), Theme(lowlight_color=identity),
+    Guide.title("group=:Dist"), Guide.ylabel(nothing)
+)
+hstack(p1, p2, p3)
+```
+
+
 ## [`Stat.x_jitter`](@ref), [`Stat.y_jitter`](@ref)
 
 ```@example

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -2252,9 +2252,9 @@ end
 UniDistributionStatistic(quantiles::Vector{Float64}=[0.0001, 0.9999]; n=40) = UniDistributionStatistic([quantiles], n)
 UniDistributionStatistic(quantiles::Vector{Vector{Float64}}; n=40) = UniDistributionStatistic(quantiles, n)
 
-Stat.input_aesthetics(stat::UniDistributionStatistic) = [:y]
-Stat.output_aesthetics(stat::UniDistributionStatistic) = [:x, :y]
-Stat.default_scales(stat::UniDistributionStatistic) = [Scale.y_distribution()]
+input_aesthetics(stat::UniDistributionStatistic) = [:y]
+output_aesthetics(stat::UniDistributionStatistic) = [:x, :y]
+default_scales(stat::UniDistributionStatistic) = [Scale.y_distribution()]
 
 """
     Stat.unidistribution(quantiles::Vector{Vector}; n=40)
@@ -2268,7 +2268,7 @@ $(aes2str(output_aesthetics(unidistribution()))). These points can be drawn with
 const unidistribution = UniDistributionStatistic
 
 
-function Stat.apply_statistic(stat::UniDistributionStatistic,
+function apply_statistic(stat::UniDistributionStatistic,
                          scales::Dict{Symbol, Gadfly.ScaleElement},
                          coord::Gadfly.CoordinateElement,
                          aes::Gadfly.Aesthetics)
@@ -2280,7 +2280,7 @@ function Stat.apply_statistic(stat::UniDistributionStatistic,
     aes_color = colorflag ? aes.color : fill("", length(aes.y))
     aes_group = groupflag ? aes.group : fill("", length(aes.y))
     aes_linestyle = linestyleflag ? aes.linestyle : fill(nothing, length(aes.y))
-        
+
     XT, CT, LT, GT = eltype(aes.y[1]), eltype(aes_color), eltype(aes_linestyle), eltype(aes_group)
     dist_x, dist_y  = XT[], XT[]
     pcolors, plinestyles, pgroups = CT[], LT[], GT[]

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -2243,4 +2243,103 @@ function apply_statistic(stat::QuantileBarsStatistic,
     aes.y_label = Gadfly.Scale.identity_formatter
 end
 
+
+struct UniDistributionStatistic <: Gadfly.StatisticElement
+    quantiles::Vector{Vector{Float64}}
+    n::Int
+end
+
+UniDistributionStatistic(quantiles::Vector{Float64}=[0.0001, 0.9999]; n=40) = UniDistributionStatistic([quantiles], n)
+UniDistributionStatistic(quantiles::Vector{Vector{Float64}}; n=40) = UniDistributionStatistic(quantiles, n)
+
+Stat.input_aesthetics(stat::UniDistributionStatistic) = [:y]
+Stat.output_aesthetics(stat::UniDistributionStatistic) = [:x, :y]
+Stat.default_scales(stat::UniDistributionStatistic) = [Scale.y_distribution()]
+
+"""
+    Stat.unidistribution(quantiles::Vector{Vector}; n=40)
+
+Transform a univariate distribution in $(aes2str(input_aesthetics(unidistribution()))) into a set of points in
+$(aes2str(output_aesthetics(unidistribution()))). These points can be drawn with `Geom.ribbon` and/or `Geom.line`. 
+`color` and `group` work alternately to specify quantile groups, depending on whether multiple distributions are specified by `group` or `color`. 
+`quantiles` is a set of 2-length vectors, specifying the quantile ranges to be plotted (default is `[[0.0001,0.9999]]`).
+`n` is the number of points in each quantile group.
+"""
+const unidistribution = UniDistributionStatistic
+
+
+function Stat.apply_statistic(stat::UniDistributionStatistic,
+                         scales::Dict{Symbol, Gadfly.ScaleElement},
+                         coord::Gadfly.CoordinateElement,
+                         aes::Gadfly.Aesthetics)
+    
+    Gadfly.assert_aesthetics_defined("Stat.unidistribution", aes, :y)
+    colorflag = aes.color != nothing
+    groupflag = aes.group != nothing
+    linestyleflag = aes.linestyle != nothing
+    aes_color = colorflag ? aes.color : fill("", length(aes.y))
+    aes_group = groupflag ? aes.group : fill("", length(aes.y))
+    aes_linestyle = linestyleflag ? aes.linestyle : fill(nothing, length(aes.y))
+        
+    XT, CT, LT, GT = eltype(aes.y[1]), eltype(aes_color), eltype(aes_linestyle), eltype(aes_group)
+    dist_x, dist_y  = XT[], XT[]
+    pcolors, plinestyles, pgroups = CT[], LT[], GT[]
+    
+    nq = length(stat.quantiles)
+    n = stat.n
+    if nq==1
+        for (d, c, g, ls) in Compose.cyclezip(aes.y, aes_color, aes_group, aes_linestyle)
+            q = quantile(d, stat.quantiles[1])
+            x = range(q..., length=n)
+            append!(dist_x, x)
+            append!(dist_y, pdf.(d, x))
+            append!(pcolors, fill(c, n))
+            append!(pgroups, fill(g, n))
+            append!(plinestyles, fill(ls, n))
+        end
+    elseif (colorflag && !groupflag)
+        for qs in stat.quantiles
+            for (d, c, g, ls) in Compose.cyclezip(aes.y, aes_color, [string(qs)], aes_linestyle)
+                q = quantile(d, qs)
+                x = range(q..., length=n)
+                append!(dist_x, x)
+                append!(dist_y, pdf.(d, x))
+                append!(pcolors, fill(c, n))
+                append!(pgroups, fill(g, n))
+                append!(plinestyles, fill(ls, n))
+            end
+        end
+        group_scale = get(scales, :group, Gadfly.Scale.group_discrete())
+        Scale.apply_scale(group_scale, [aes], Gadfly.Data(group=pgroups))
+    elseif (groupflag && !colorflag)
+        for qs in stat.quantiles
+            for (d, c, g, ls) in Compose.cyclezip(aes.y, [string(qs)], aes_group, aes_linestyle)
+                q = quantile(d, qs)
+                x = range(q..., length=n)
+                append!(dist_x, x)
+                append!(dist_y, pdf.(d, x))
+                append!(pcolors, fill(c, n))
+                append!(pgroups, fill(g, n))
+                append!(plinestyles, fill(ls, n))
+            end
+        end
+        color_scale = get(scales, :color, Gadfly.Scale.color_discrete())
+        Scale.apply_scale(color_scale, [aes], Gadfly.Data(color=pcolors))
+    else
+        error("""For `Stat.unidistribution`, use either `color` or `group`, not both.""")        
+    end
+    aes.x = dist_x
+    aes.ymin = [0.0]
+    aes.ymax = dist_y
+    aes.y = dist_y
+    colorflag && (aes.color = pcolors)
+    groupflag && (aes.group = IndirectArray(pgroups))
+    linestyleflag && (aes.linestyle = plinestyles)
+    x_scale = get(scales, :x, Scale.x_continuous())
+    y_scale = get(scales, :y, Scale.y_continuous())
+    Scale.apply_scale(x_scale, [aes], Gadfly.Data(x=aes.x))
+    Scale.apply_scale(y_scale, [aes], Gadfly.Data(y=aes.y))
+end
+
+
 end # module Stat

--- a/test/testscripts/stat_unidistribution.jl
+++ b/test/testscripts/stat_unidistribution.jl
@@ -1,0 +1,18 @@
+
+using Distributions, Gadfly, RDatasets
+set_default_plot_size(21cm, 8cm)
+iris = dataset("datasets", "iris")
+df = combine(groupby(iris, :Species), :SepalLength=>(x->fit(Normal, x))=>:Density)
+
+
+gck = Guide.colorkey(title="", pos=[7, 2.0])
+
+p1 = plot(df, y=:Density, color=:Species, gck,
+    layer(Stat.unidistribution, Geom.line),
+    layer(Stat.unidistribution([[0.0001, 0.05], [0.95, 0.9999]]), Geom.ribbon, alpha=[0.8]))
+p2 = plot(df, y=:Density, group=:Species, gck,
+    layer(Stat.unidistribution, Geom.line, color=[colorant"silver"]),
+    layer(Stat.unidistribution([[0.0001, 0.1], [0.9, 0.9999]]), Geom.ribbon, alpha=[0.7]),
+    Scale.color_discrete_manual("deepskyblue", "forestgreen"), Theme(lowlight_color=identity))
+hstack(p1, p2)
+


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've added an entry to `NEWS.md`
- [x] Add a test and run the regression tests
- [x] I've built the docs and confirmed these changes don't cause new errors


## This PR:

- Adds `Stat.unidistribution`
- from https://github.com/GiovineItalia/Gadfly.jl/issues/1489#issuecomment-716226737
- Also adds the ability to specify the quantile ranges to plot (which will auto-use either `color` or `group`)

## Example

```julia
using Distributions
D = DataFrame(Dist=["Prior", "Posterior"],  
    Density=[Normal(-0.22, 0.02), Normal(-0.29, 0.015)])
xcoord = Coord.cartesian(xmin=-0.4, xmax=-0.1)
gck = Guide.colorkey(title="", pos=[0.5w, -0.4h])
p1 = plot(D, y=:Density, color=:Dist, Guide.title("color=:Dist"), gck,
    layer(Stat.unidistribution, Geom.line, Geom.ribbon, alpha=[0.8]), xcoord)
p2 = plot(D, y=:Density, color=:Dist, layer(Stat.unidistribution, Geom.line),
    layer(Stat.unidistribution([[0.0001, 0.05], [0.95, 0.9999]]), Geom.ribbon),
    Guide.ylabel(nothing), Guide.title("color=:Dist"), gck)
p3 = plot(D, y=:Density, group=:Dist, xcoord, gck,
    layer(Stat.unidistribution([[0.0001, 0.1],[0.1, 0.9], [0.9, 0.9999]]), Geom.ribbon, alpha=[0.8]),
    Scale.color_discrete_manual("orange", "yellow", "coral"), Theme(lowlight_color=identity),
    Guide.title("group=:Dist"), Guide.ylabel(nothing))

hstack(p1,p2,p3)
```



![issue1489](https://user-images.githubusercontent.com/18226881/218306926-7afd9728-784f-4ffd-b08c-09b32c45b625.png)

