### PR TITLE
bump minor version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Gadfly"
 uuid = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
-version = "1.3.4"
+version = "1.4.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
@Mattriks @tlnagy main impetus for doing this is that gadfly is holding up upgrading many of it's dependents.  there are also a few new features, hence bumping the minor version instead of the patch.  you two okay with merging this?